### PR TITLE
Really fix camera identification (fixes #21)

### DIFF
--- a/src/avio.jl
+++ b/src/avio.jl
@@ -553,22 +553,27 @@ if have_avdevice()
         CAMERA_DEVICES = UTF8String[]
 
         read_vid_devs = false
-        try
-            open(`$ffmpeg -list_devices true -f $idev -i $idev_name`) do io
-                for line in eachline(io)
-                    if contains(line, "video devices")
-                        read_vid_devs = true
-                        continue
-                    elseif contains(line, "audio devices") || contains(line, "exit") || contains(line, "error")
-                        read_vid_devs = false
-                        continue
-                    end
-                    if read_vid_devs
-                        m = match(r"""\[.*"(.*)".?""", line)
-                        if m != nothing
-                            push!(CAMERA_DEVICES, m.captures[1])
-                        end
-                    end
+        out,err = readall_stdout_stderr(`$ffmpeg -list_devices true -f $idev -i $idev_name`)
+        buf = length(out) > 0 ? out : err
+        for line in eachline(IOBuffer(buf))
+            if contains(line, "video devices")
+                read_vid_devs = true
+                continue
+            elseif contains(line, "audio devices") || contains(line, "exit") || contains(line, "error")
+                read_vid_devs = false
+                continue
+            end
+
+            if read_vid_devs
+                m = match(r"""\[.*"(.*)".?""", line)
+                if m != nothing
+                    push!(CAMERA_DEVICES, m.captures[1])
+                end
+
+                # Alternative format (TODO: could be combined with the regex above)
+                m = match(r"""\[.*\] \[[0-9]\] (.*)""", line)
+                if m != nothing
+                    push!(CAMERA_DEVICES, m.captures[1])
                 end
             end
         end


### PR DESCRIPTION
- Newer versions of ffmpeg write to stderr instead of stdout
- Added utility functions open_stdout_stderr, readall_stdout_stderr
- Using these, make sure we capture output of ffmpeg command used
  to identify the camera on OSX and (hopefully) windows

This works for me with the latest ffmpeg on OSX.  I don't have a Windows machine to test on.  @ihnorton, do you have time to test this?

Ideally, we'll get the camera names and parameters after #47 is merged, but hopefully this works as a stopgap.

Cc: @maxruby, @ihnorton 
