### PR TITLE
WIP: Turn on precompilation

### DIFF
--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -1,4 +1,4 @@
-__precompile__(false)
+__precompile__(true)
 
 module VideoIO
 
@@ -6,14 +6,33 @@ using FixedPointNumbers, ColorTypes, ImageCore
 
 include("init.jl")
 
-using AVUtil
-using AVCodecs
-using AVFormat
-using SWScale
+include(joinpath(dirname(@__FILE__), ffmpeg_or_libav, "AVUtil", "src", "AVUtil.jl"))
+using .AVUtil
+include(joinpath(dirname(@__FILE__), ffmpeg_or_libav, "AVCodecs", "src", "AVCodecs.jl"))
+using .AVCodecs
+include(joinpath(dirname(@__FILE__), ffmpeg_or_libav, "AVFormat", "src", "AVFormat.jl"))
+using .AVFormat
+include(joinpath(dirname(@__FILE__), ffmpeg_or_libav, "SWScale", "src", "SWScale.jl"))
+using .SWScale
+
+if have_avdevice()
+    include(joinpath(dirname(@__FILE__), ffmpeg_or_libav, "AVDevice", "src", "AVDevice.jl"))
+    import .AVDevice
+    include("camera.jl")
+end
 
 include("util.jl")
 include("avio.jl")
 include("testvideos.jl")
 using .TestVideos
+
+function __init__()
+    # Register all codecs and formats
+    av_register_all()
+    av_log_set_level(AVUtil.AV_LOG_ERROR)
+    if have_avdevice()
+        AVDevice.avdevice_register_all()
+    end
+end
 
 end # VideoIO

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -183,11 +183,6 @@ function open_avinput(avin::AVInput, source::AbstractString, input_format=C_NULL
 end
 
 function AVInput{T<:Union{IO, AbstractString}}(source::T, input_format=C_NULL; avio_ctx_buffer_size=65536)
-
-    # Register all codecs and formats
-    av_register_all()
-    av_log_set_level(AVUtil.AV_LOG_ERROR)
-
     aPacket = [AVPacket()]
     apFormatContext = Ptr{AVFormatContext}[avformat_alloc_context()]
     apAVIOContext = Ptr{AVIOContext}[C_NULL]

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -100,9 +100,10 @@ function pump(c::AVInput)
     while true
         !c.isopen && break
 
-        Base.sigatomic_begin()
-        av_read_frame(pFormatContext, pointer(c.aPacket)) < 0 && break
-        Base.sigatomic_end()
+        ret = Base.disable_sigint() do
+            av_read_frame(pFormatContext, pointer(c.aPacket))
+        end
+        ret < 0 && break
 
         packet = c.aPacket[1]
         stream_index = packet.stream_index

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -284,7 +284,7 @@ function VideoReader(avin::AVInput, video_stream=1;
     end
 
     N = Int64(bits_per_pixel >> 3)
-    target_buf = Array(UInt8, bits_per_pixel>>3, width, height)
+    target_buf = Array{UInt8}(bits_per_pixel>>3, width, height)
 
     sws_context = sws_getContext(width, height, pix_fmt,
                                  width, height, target_format,

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -1,0 +1,71 @@
+### Camera Functions
+
+function get_camera_devices(ffmpeg, idev, idev_name)
+    CAMERA_DEVICES = String[]
+
+    read_vid_devs = false
+    out,err = readall_stdout_stderr(`$ffmpeg -list_devices true -f $idev -i $idev_name`)
+    buf = length(out) > 0 ? out : err
+    for line in eachline(IOBuffer(buf))
+        if contains(line, "video devices")
+            read_vid_devs = true
+            continue
+        elseif contains(line, "audio devices") || contains(line, "exit") || contains(line, "error")
+            read_vid_devs = false
+            continue
+        end
+
+        if read_vid_devs
+            m = match(r"""\[.*"(.*)".?""", line)
+            if m != nothing
+                push!(CAMERA_DEVICES, m.captures[1])
+            end
+
+            # Alternative format (TODO: could be combined with the regex above)
+            m = match(r"""\[.*\] \[[0-9]\] (.*)""", line)
+            if m != nothing
+                push!(CAMERA_DEVICES, m.captures[1])
+            end
+        end
+    end
+
+    return CAMERA_DEVICES
+end
+
+if is_windows()
+    ffmpeg = joinpath(dirname(@__FILE__), "..", "deps", "ffmpeg-2.2.3-win$WORD_SIZE-shared", "bin", "ffmpeg.exe")
+
+    DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("dshow")
+    CAMERA_DEVICES = get_camera_devices(ffmpeg, "dshow", "dummy")
+    DEFAULT_CAMERA_DEVICE = length(CAMERA_DEVICES) > 0 ? CAMERA_DEVICES[1] : "0"
+
+end
+
+if is_linux()
+    import Glob
+    DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("video4linux2")
+    CAMERA_DEVICES = Glob.glob("video*", "/dev")
+    DEFAULT_CAMERA_DEVICE = length(CAMERA_DEVICES) > 0 ? CAMERA_DEVICES[1] : ""
+end
+
+if is_apple()
+    ffmpeg = joinpath(INSTALL_ROOT, "bin", "ffmpeg")
+
+    DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("avfoundation")
+    global CAMERA_DEVICES = String[]
+    try
+        CAMERA_DEVICES = get_camera_devices(ffmpeg, "avfoundation", "\"\"")
+    catch
+        try
+            CAMERA_DEVICES = get_camera_devices(ffmpeg, "qtkit", "\"\"")
+        end
+    end
+
+    DEFAULT_CAMERA_DEVICE = length(CAMERA_DEVICES) > 0 ? CAMERA_DEVICES[1] : "FaceTime"
+    #DEFAULT_CAMERA_DEVICE = "Integrated"
+end
+
+function opencamera(device=DEFAULT_CAMERA_DEVICE, format=DEFAULT_CAMERA_FORMAT, args...; kwargs...)
+    camera = AVInput(device, format)
+    VideoReader(camera, args...; kwargs...)
+end

--- a/src/ffmpeg/AVCodecs/src/AVCodecs.jl
+++ b/src/ffmpeg/AVCodecs/src/AVCodecs.jl
@@ -2,11 +2,11 @@ module AVCodecs
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(avcodec_dir, f)
 
-  using AVUtil
+  using ..AVUtil
 
   include(w("LIBAVCODEC.jl"))
 
   AVPacket() = AVPacket([T<:Ptr ? C_NULL : zero(T) for T in AVPacket.types]...)
-  
+
 end
 

--- a/src/ffmpeg/AVDevice/src/AVDevice.jl
+++ b/src/ffmpeg/AVDevice/src/AVDevice.jl
@@ -2,8 +2,8 @@ module AVDevice
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(avdevice_dir, f)
 
-  using AVUtil
-  using AVFormat
-  using AVCodecs
+  using ..AVUtil
+  using ..AVFormat
+  using ..AVCodecs
   include(w("LIBAVDEVICE.jl"))
 end

--- a/src/ffmpeg/AVFormat/src/AVFormat.jl
+++ b/src/ffmpeg/AVFormat/src/AVFormat.jl
@@ -2,8 +2,8 @@ module AVFormat
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(avformat_dir, f)
 
-  using AVUtil
-  using AVCodecs
+  using ..AVUtil
+  using ..AVCodecs
 
   include(w("LIBAVFORMAT.jl"))
 end

--- a/src/ffmpeg/SWScale/src/SWScale.jl
+++ b/src/ffmpeg/SWScale/src/SWScale.jl
@@ -2,6 +2,6 @@ module SWScale
   include(joinpath(dirname(@__FILE__),"..","..","..","init.jl"))
   w(f) = joinpath(swscale_dir, f)
 
-  using AVUtil
+  using ..AVUtil
   include(w("LIBSWSCALE.jl"))
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -5,18 +5,8 @@ using BinDeps
 #        avcodec_version, avformat_version, avutil_version, swscale_version, avdevice_version, avfilter_version, avresample_version, swresample_version,
 #        libavcodec, libavformat, libavutil, libswscale, libavdevice, libavfilter, libavresample, libswresample,
 
-if !isdefined(:libavcodec)
-    include("../deps/deps.jl")
-end
+include("../deps/deps.jl")
 
 INSTALL_ROOT = realpath(joinpath(splitdir(libavcodec)[1], ".."))
 
-if !isdefined(:ffmpeg_or_libav)
-    include("version.jl")
-end
-
-av_load_path = joinpath(dirname(@__FILE__), ffmpeg_or_libav)
-!(av_load_path in LOAD_PATH) && unshift!(LOAD_PATH, av_load_path)
-
-
-
+include("version.jl")

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -22,9 +22,9 @@ for name in VideoIO.TestVideos.names()
     println(STDERR, "   Testing $name...")
 
     first_frame_file = joinpath(testdir, swapext(name, ".png"))
-    fiftieth_frame_file = joinpath(testdir, swapext(name, "")*"50.png") 
+    fiftieth_frame_file = joinpath(testdir, swapext(name, "")*"50.png")
     first_frame = load(first_frame_file) # comment line when creating png files
-   
+
     f = VideoIO.testvideo(name)
     v = VideoIO.openvideo(f)
 
@@ -43,7 +43,7 @@ for name in VideoIO.TestVideos.names()
 
     @test img == first_frame               # comment line when creating png files
 
-    
+
     for i in 1:50
         read!(v,img)
     end
@@ -54,7 +54,7 @@ for name in VideoIO.TestVideos.names()
 
     seek(v,float(fiftytime))
     read!(v,img)
-    
+
     @test img == fiftieth_frame
 
     while !eof(v)
@@ -81,7 +81,7 @@ for name in VideoIO.TestVideos.names()
     (startswith(name, "ladybird") || startswith(name, "NPS")) && continue
 
     println(STDERR, "   Testing $name...")
-    first_frame_file = joinpath(testdir, swapext(name, ".png")) 
+    first_frame_file = joinpath(testdir, swapext(name, ".png"))
     first_frame = load(first_frame_file) # comment line when creating png files
 
     filename = joinpath(videodir, name)
@@ -100,7 +100,7 @@ for name in VideoIO.TestVideos.names()
 
     #save(first_frame_file,img)        # uncomment line when creating png files
 
-    @test img == first_frame               # comment line when creating png files   
+    @test img == first_frame               # comment line when creating png files
 
     while !eof(v)
         read!(v, img)


### PR DESCRIPTION
This is a not-yet-working attempt to use precompilation. It switches to using internal submodules rather than modifying `LOAD_PATH`, and (for now) it simply comments out the code that's conditional on ImageView being loaded. Before merging this we should decide on a more "serious" solution to this issue, such as:
- create a WebCam.jl package that depends on both VideoIO and ImageView
- have VideoIO return objects that ImageView can handle. For example, `opencamera` (or some higher-level wrapper) could conceivable return a [`StreamingContainer`](https://github.com/JuliaImages/ImageAxes.jl/blob/3e9d83e7c5d15184616e9b6ae6129e5402a38385/src/ImageAxes.jl#L193-L225) or something similar. Likewise, now that we have `seek` functionality, perhaps we could create a `VideoArray<:AbstractArray` that has the standard AbstractArray interface and lets ImageView (and any other Julia code) treat the movie file as if it's a giant array.

However, there's a more immediate problem: the tests don't pass. With precompilation, I get this:
```julia
julia> include("runtests.jl")
WARNING: Method definition zero(Type{VideoIO.AVUtil.AVRational}) in module AVUtil at /home/tim/.julia/v0.6/VideoIO/src/ffmpeg/AVUtil/src/../../../ffmpeg/AVUtil/v54/libavutil_h.jl:691 overwritten at /home/tim/.julia/v0.6/VideoIO/src/ffmpeg/AVUtil/src/AVUtil.jl:7.
VideoFile:
   name:         annie_oakley.ogg  (Downloaded)
   description:  The "Little Sure Shot" of the "Wild West," exhibition of rifle shooting at glass balls.
   license:      pubic_domain (US)
   credit:       
   source:       http://commons.wikimedia.org/wiki/File:Annie_Oakley_shooting_glass_balls,_1894.ogg
   download_url: https://upload.wikimedia.org/wikipedia/commons/8/87/Annie_Oakley_shooting_glass_balls%2C_1894.ogv
 
WARNING: deprecated syntax "abstract StreamContext".
Use "abstract type StreamContext end" instead.

VideoFile:
   name:         crescent-moon.ogv  (Downloaded)
   description:  Moonset (time-lapse).
   license:      Creative Commons Attribution 2.0 Generic (http://creativecommons.org/licenses/by/2.0/deed)
   credit:       Photo : Thomas Bresson
   source:       http://commons.wikimedia.org/wiki/File:2010-10-10-Lune.ogv
   download_url: http://upload.wikimedia.org/wikipedia/commons/e/ef/2010-10-10-Lune.ogv
 
VideoFile:
   name:         ladybird.mp4  (Downloaded)
   description:  Ladybird opening wings (slow motion)
   license:      Creative Commons: By Attribution 3.0 Unported (http://creativecommons.org/licenses/by/3.0/deed)
   credit:       CC-BY NatureClip (http://youtube.com/natureclip)
   source:       http://downloadnatureclip.blogspot.com/p/download-links.html
   download_url: https://archive.org/download/LadybirdOpeningWingsCCBYNatureClip/Ladybird%20opening%20wings%20CC-BY%20NatureClip.mp4
 
VideoFile:
   name:         black_hole.webm  (Downloaded)
   description:  Artist’s impression of the black hole inside NGC 300 X-1 (ESO 1004c)
   license:      Creative Commons Attribution 3.0 Unported (http://creativecommons.org/licenses/by/3.0/deed)
   credit:       Credit: ESO/L. Calçada
   source:       http://www.eso.org/public/videos/eso1004a/
   download_url: http://upload.wikimedia.org/wikipedia/commons/1/13/Artist%E2%80%99s_impression_of_the_black_hole_inside_NGC_300_X-1_%28ESO_1004c%29.webm
 
Testing file reading...
Testing IO reading...
   Testing annie_oakley.ogg...
[aac @ 0x4ac4740] Number of bands (31) exceeds limit (1).
[aac @ 0x4ac4740] channel element 0.0 is not allocated
[aac @ 0x4ac4740] channel element 0.0 is not allocated
[aac @ 0x4ac4740] channel element 2.0 is not allocated
[aac @ 0x4ac4740] Number of bands (31) exceeds limit (1).
[aac @ 0x4ac4740] Error decoding AAC frame header.
[aac @ 0x4ac4740] channel element 0.0 is not allocated
[aac @ 0x4ac4740] Number of scalefactor bands in group (49) exceeds limit (43).
[aac @ 0x4ac4740] Number of bands (31) exceeds limit (1).
[aac @ 0x4ac4740] Error decoding AAC frame header.
[aac @ 0x4ac4740] Number of bands (31) exceeds limit (1).
[aac @ 0x4ac4740] Error decoding AAC frame header.
[aac @ 0x4ac4740] Prediction is not allowed in AAC-LC.
[aac @ 0x4ac4740] Error decoding AAC frame header.
[aac @ 0x4ac4740] Number of bands (31) exceeds limit (1).
[aac @ 0x4ac4740] Error decoding AAC frame header.
[aac @ 0x4ac4740] Prediction is not allowed in AAC-LC.
[aac @ 0x4ac4740] Number of bands (31) exceeds limit (1).
[aac @ 0x4ac4740] Number of scalefactor bands in group (49) exceeds limit (43).
[aac @ 0x4ac4740] Prediction is not allowed in AAC-LC.
[aac @ 0x4ac4740] Number of bands (31) exceeds limit (1).
[aac @ 0x4ac4740] Error decoding AAC frame header.
[aac @ 0x4ac4740] Prediction is not allowed in AAC-LC.
[aac @ 0x4ac4740] Error decoding AAC frame header.
[aac @ 0x4ac4740] Prediction is not allowed in AAC-LC.
[aac @ 0x4ac4740] Prediction is not allowed in AAC-LC.
ERROR: LoadError: LoadError: Unable to find stream information
Stacktrace:
 [1] #AVInput#3(::Int64, ::Type{T} where T, ::IOStream, ::Ptr{Void}) at /home/tim/.julia/v0.6/VideoIO/src/avio.jl:203
 [2] #VideoReader#7(::Array{Any,1}, ::Type{T} where T, ::IOStream) at /home/tim/.julia/v0.6/VideoIO/src/avio.jl:329
 [3] VideoIO.VideoReader(::IOStream) at /home/tim/.julia/v0.6/VideoIO/src/avio.jl:329
 [4] #openvideo#8(::Array{Any,1}, ::Function, ::IOStream, ::Vararg{IOStream,N} where N) at /home/tim/.julia/v0.6/VideoIO/src/avio.jl:447
 [5] macro expansion at /home/tim/.julia/v0.6/VideoIO/test/avio.jl:88 [inlined]
 [6] anonymous at ./<missing>:?
 [7] include_from_node1(::String) at ./loading.jl:576
 [8] include(::String) at ./sysimg.jl:14
 [9] include_from_node1(::String) at ./loading.jl:576
 [10] include(::String) at ./sysimg.jl:14
while loading /home/tim/.julia/v0.6/VideoIO/test/avio.jl, in expression starting on line 78
while loading /home/tim/.julia/v0.6/VideoIO/test/runtests.jl, in expression starting on line 1

julia> 
```
However, if I keep all these other changes but simply go back to `__precompile__(false)`, then the tests pass.

I suspect I need to add something else to my `__init__` function, but I'm not enough of an ffmpeg guru to figure it out easily (and I've spent a while searching). Any ideas?
