### PR TITLE
Enable precompilation(!!!)

### DIFF
--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -1,5 +1,3 @@
-__precompile__(false)
-
 module VideoIO
 
 using FixedPointNumbers, ColorTypes, ImageCore, Requires
@@ -22,6 +20,8 @@ include("testvideos.jl")
 using .TestVideos
 
 function __init__()
+    global read_packet  =  @cfunction(_read_packet, Cint, (Ptr{AVInput}, Ptr{UInt8}, Cint))
+
     @require ImageView = "86fae568-95e7-573e-a6b2-d8a6b900c9ef" begin
         # Define read and retrieve for Images
         function play(f, flip=false)

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -130,9 +130,6 @@ function _read_packet(pavin::Ptr{AVInput}, pbuf::Ptr{UInt8}, buf_size::Cint)
     convert(Cint, readbytes!(avin.io, out))
 end
 
-const read_packet  =  @cfunction(_read_packet, Cint, (Ptr{AVInput}, Ptr{UInt8}, Cint))
-
-
 function open_avinput(avin::AVInput, io::IO, input_format=C_NULL)
 
     !isreadable(io) && error("IO not readable")
@@ -637,7 +634,7 @@ if have_avdevice()
         close(out.in); close(err.in)
         err_s = readlines(err)
         out_s = readlines(out)
-        
+
         lines = length(out_s) > length(err_s) ? out_s : err_s
 
         for line in lines


### PR DESCRIPTION
The test (and code) that was failing for precompilation was code that reads from a Julia `IOStream`.  Reading inputs directly with ffmpeg's own I/O functions was working fine.

In order to read from a Julia `IOStream`, we pass a callback function which fills a pre-allocated buffer with data from the stream.  The pointer to that callback has to be determined at runtime (in `__init__`), because the function location will change each time the program is run.

Cc: @timholy @ianshmean 