### PR TITLE
Add `ColorTypes.gray` pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ This code is essentially the code in `playvideo`, and will read and
 As with the `playvideo` function, the `Images` and `ImageView` packages
 must be loaded for the appropriate functions to be available.
 
+As an example, here a grayscale video is read and parsed into a `Vector(Array{UInt8}}`
+```
+f = VideoIO.openvideo(filename,target_format=VideoIO.AV_PIX_FMT_GRAY8)
+v = Vector{Array{UInt8}}(undef,0)
+while !eof(f)
+    push!(v,reinterpret(UInt8, read(f)))
+end
+close(f)
+```
+
 
 Low Level Interface
 -------------------

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -13,7 +13,7 @@ end
 
 abstract type StreamContext end
 
-const EightBitTypes = Union{UInt8,N0f8,ColorTypes.RGB{N0f8}}
+const EightBitTypes = Union{UInt8,N0f8,ColorTypes.RGB{N0f8},ColorTypes.Gray{N0f8}}
 const PermutedArray{T,N,perm,iperm,AA <: Array} = Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm,iperm,AA}
 const VidArray{T,N} = Union{Array{T,N},PermutedArray{T,N}}
 


### PR DESCRIPTION
Hopefully a simple change to enable grayscale UInt8 based videos.

Also added an example for reading in a full video