### PR TITLE
Fix camera initialization

### DIFF
--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -14,14 +14,63 @@ using .AVCodecs
 using .AVFormat
 using .SWScale
 
+if have_avdevice()
+    import .AVDevice
+end
+
 include("util.jl")
 include("avio.jl")
 include("testvideos.jl")
 using .TestVideos
 
+if Sys.islinux()
+    import Glob
+end
+
 function __init__()
     global read_packet
     read_packet[] = @cfunction(_read_packet, Cint, (Ptr{AVInput}, Ptr{UInt8}, Cint))
+
+    av_register_all()
+
+    if have_avdevice()
+        AVDevice.avdevice_register_all()
+
+        if Sys.iswindows()
+            ffmpeg = joinpath(dirname(@__FILE__), "..", "deps", "ffmpeg-4.1-win$(Sys.WORD_SIZE)-shared", "bin", "ffmpeg.exe")
+
+            global DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("dshow")
+            global CAMERA_DEVICES
+            push!(CAMERA_DEVICES, get_camera_devices(ffmpeg, "dshow", "dummy")...)
+            global DEFAULT_CAMERA_DEVICE = length(CAMERA_DEVICES) > 0 ? CAMERA_DEVICES[1] : "0"
+
+        end
+
+        if Sys.islinux()
+            global DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("video4linux2")
+            global CAMERA_DEVICES = Glob.glob("video*", "/dev")
+            global DEFAULT_CAMERA_DEVICE = length(CAMERA_DEVICES) > 0 ? CAMERA_DEVICES[1] : ""
+        end
+
+        if Sys.isapple()
+            ffmpeg = joinpath(INSTALL_ROOT, "bin", "ffmpeg")
+
+            global CAMERA_DEVICES = String[]
+            try
+                global CAMERA_DEVICES = get_camera_devices(ffmpeg, "avfoundation", "\"\"")
+                global DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("avfoundation")
+            catch
+                try
+                    global CAMERA_DEVICES = get_camera_devices(ffmpeg, "qtkit", "\"\"")
+                    global DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("qtkit")
+                catch
+                end
+            end
+
+            # Note: "Integrated" is another possible default value
+            DEFAULT_CAMERA_DEVICE = length(CAMERA_DEVICES) > 0 ? CAMERA_DEVICES[1] : "FaceTime"
+        end
+    end
 
     @require ImageView = "86fae568-95e7-573e-a6b2-d8a6b900c9ef" begin
         # Define read and retrieve for Images

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -184,7 +184,6 @@ end
 function AVInput(source::T, input_format=C_NULL; avio_ctx_buffer_size=65536) where T <: Union{IO,AbstractString}
 
     # Register all codecs and formats
-    av_register_all()
     av_log_set_level(AVUtil.AV_LOG_ERROR)
 
     aPacket = [AVPacket()]
@@ -624,10 +623,12 @@ end
 
 ### Camera Functions
 
-if have_avdevice()
-    import .AVDevice
-    AVDevice.avdevice_register_all()
+# These are set in __init__()
+DEFAULT_CAMERA_FORMAT = Ptr{AVFormat.AVInputFormat}(C_NULL)
+CAMERA_DEVICES = String[]
+DEFAULT_CAMERA_DEVICE = ""
 
+if have_avdevice()
     function get_camera_devices(ffmpeg, idev, idev_name)
         camera_devices = String[]
 
@@ -667,39 +668,6 @@ if have_avdevice()
         return camera_devices
     end
 
-    if Sys.iswindows()
-        ffmpeg = joinpath(dirname(@__FILE__), "..", "deps", "ffmpeg-4.1-win$(Sys.WORD_SIZE)-shared", "bin", "ffmpeg.exe")
-
-        DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("dshow")
-        CAMERA_DEVICES = get_camera_devices(ffmpeg, "dshow", "dummy")
-        DEFAULT_CAMERA_DEVICE = length(CAMERA_DEVICES) > 0 ? CAMERA_DEVICES[1] : "0"
-
-    end
-
-    if Sys.islinux()
-        import Glob
-        DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("video4linux2")
-        CAMERA_DEVICES = Glob.glob("video*", "/dev")
-        DEFAULT_CAMERA_DEVICE = length(CAMERA_DEVICES) > 0 ? CAMERA_DEVICES[1] : ""
-    end
-
-    if Sys.isapple()
-        ffmpeg = joinpath(INSTALL_ROOT, "bin", "ffmpeg")
-
-        DEFAULT_CAMERA_FORMAT = AVFormat.av_find_input_format("avfoundation")
-        global CAMERA_DEVICES = String[]
-        try
-            global CAMERA_DEVICES = get_camera_devices(ffmpeg, "avfoundation", "\"\"")
-        catch
-            try
-                global CAMERA_DEVICES = get_camera_devices(ffmpeg, "qtkit", "\"\"")
-            catch
-            end
-        end
-
-        DEFAULT_CAMERA_DEVICE = length(CAMERA_DEVICES) > 0 ? CAMERA_DEVICES[1] : "FaceTime"
-        #DEFAULT_CAMERA_DEVICE = "Integrated"
-    end
 
     function opencamera(device=DEFAULT_CAMERA_DEVICE, format=DEFAULT_CAMERA_FORMAT, args...; kwargs...)
         camera = AVInput(device, format)


### PR DESCRIPTION
* Camera device information is set in a number of global variables.  
* Because precompilation is now enabled, these need to be set in __init__()