### PR TITLE
Replace ImageView video playback with Makie

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Simple Interface
 ----------------
 A trivial video player interface exists (no audio):
 
-    import ImageView
+    import Makie
     import VideoIO
 
     f = VideoIO.testvideo("annie_oakley")  # downloaded if not available
@@ -45,8 +45,7 @@ High Level Interface
 VideoIO contains a simple high-level interface which allows reading of
 video frames from a supported video file, or from a camera device:
 
-    using Images
-    import ImageView
+    import Makie
     import VideoIO
 
     io = VideoIO.open(video_file)
@@ -65,11 +64,13 @@ video frames from a supported video file, or from a camera device:
     # One can seek to an arbitrary position in the video
     seek(f,2.5)  ## The second parameter is the time in seconds and must be Float64
     img = read(f)
-    canvas, _ = ImageView.view(img)
+    makieimg = Makie.image!(scene, buf, show_axis = false, scale_plot = false)[end]
+    Makie.rotate!(scene, -0.5pi)
+    display(scene)
 
     while !eof(f)
         read!(f, img)
-        ImageView.imshow(canvas, img)
+        makieimg[1] = img
         #sleep(1/30)
     end
 
@@ -79,7 +80,7 @@ This code is essentially the code in `playvideo`, and will read and
 As with the `playvideo` function, the `Images` and `ImageView` packages
 must be loaded for the appropriate functions to be available.
 
-As an example, here a grayscale video is read and parsed into a `Vector(Array{UInt8}}`
+As an additional handling example, here a grayscale video is read and parsed into a `Vector(Array{UInt8}}`
 ```
 f = VideoIO.openvideo(filename,target_format=VideoIO.AV_PIX_FMT_GRAY8)
 v = Vector{Array{UInt8}}(undef,0)

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -77,15 +77,19 @@ function __init__()
         end
     end
 
-    @require ImageView = "86fae568-95e7-573e-a6b2-d8a6b900c9ef" begin
+    @require Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" begin
         # Define read and retrieve for Images
         function play(f, flip=false)
+            scene = Makie.Scene(resolution = (f.width, f.height))
+            
             buf = read(f)
-            canvas, _ = ImageView.imshow(buf, flipx=flip, interactive=false)
+            hmap = Makie.image!(scene,buf, show_axis = false, scale_plot = false)[end]
+            Makie.rotate!(scene, -0.5pi)
+            display(scene)
 
             while !eof(f)
                 read!(f, buf)
-                ImageView.imshow(canvas, buf, flipx=flip, interactive=false)
+                hmap[1] = buf
                 sleep(1 / f.framerate)
             end
         end

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -83,13 +83,13 @@ function __init__()
             scene = Makie.Scene(resolution = (f.width, f.height))
             
             buf = read(f)
-            hmap = Makie.image!(scene,buf, show_axis = false, scale_plot = false)[end]
+            makieimg = Makie.image!(scene,buf, show_axis = false, scale_plot = false)[end]
             Makie.rotate!(scene, -0.5pi)
             display(scene)
 
             while !eof(f)
                 read!(f, buf)
-                hmap[1] = buf
+                makieimg[1] = buf
                 sleep(1 / f.framerate)
             end
         end

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -79,14 +79,18 @@ function __init__()
 
     @require Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" begin
         # Define read and retrieve for Images
-        function play(f, flip=false)
+        function play(f; flipx=false, flipy=false)
             scene = Makie.Scene(resolution = (f.width, f.height))
-            
             buf = read(f)
             makieimg = Makie.image!(scene,buf, show_axis = false, scale_plot = false)[end]
             Makie.rotate!(scene, -0.5pi)
+            if flipx && flipy
+                Makie.scale!(scene, -1, -1, 1)
+            else
+                flipx && Makie.scale!(scene, -1, 1, 1)
+                flipy && Makie.scale!(scene, 1, -1, 1)
+            end
             display(scene)
-
             while !eof(f)
                 read!(f, buf)
                 makieimg[1] = buf
@@ -94,15 +98,15 @@ function __init__()
             end
         end
 
-        function playvideo(video)
+        function playvideo(video;flipx=false,flipy=false)
             f = VideoIO.openvideo(video)
-            play(f)
+            play(f,flipx=flipx,flipy=flipy)
         end
 
         if have_avdevice()
             function viewcam(device=DEFAULT_CAMERA_DEVICE, format=DEFAULT_CAMERA_FORMAT)
                 camera = opencamera(device, format)
-                play(camera, true)
+                play(camera, flipx=true)
             end
         else
             function viewcam()


### PR DESCRIPTION
The current `ImageView` method seems to be broken, and this fixes it (for me at least).

It would be great to add play/pause, track, progress indicator, frame number, time etc, if those are easy to add now?

```julia
julia> using Makie, VideoIO
julia> VideoIO.playvideo("localpath/VideoIO.jl/videos/annie_oakley.ogg")
```
![image](https://user-images.githubusercontent.com/1694067/57093204-3a1b0e00-6cdb-11e9-922f-9b3b2d49afcb.png)
