### PR TITLE
duration is in microseconds not milliseconds

### DIFF
--- a/src/info.jl
+++ b/src/info.jl
@@ -4,12 +4,12 @@ function _get_fc(file::String) # convenience function for `get_duration` and `ge
     v = open(file)
     return unsafe_load(v.apFormatContext[1])
 end
-get_duration(fc::AVFormatContext) = Dates.Millisecond(fc.duration) # this is a bit risky: if AV_TIME_BASE ≠ 1e6 then this conversion will give false results, or if `fc.duration` is not a whole number then this will result in an InexactError. I'll add the appropriate checks if you'll tell me that either event or both are possible.
+get_duration(fc::AVFormatContext) = Dates.Microsecond(fc.duration) # this is a bit risky: if AV_TIME_BASE ≠ 1e6 then this conversion will give false results, or if `fc.duration` is not a whole number then this will result in an InexactError. I'll add the appropriate checks if you'll tell me that either event or both are possible.
 
 """
-    get_duration(file::String) -> Millisecond
+    get_duration(file::String) -> Microsecond
 
-Return the duration of the video `file` in `Millisecond`s.
+Return the duration of the video `file` in `Microsecond`s.
 """
 get_duration(file::String) = get_duration(_get_fc(file))
 
@@ -25,7 +25,7 @@ get_start_time(file::String) = get_start_time(_get_fc(file))
 get_time_duration(fc::AVFormatContext) = (get_start_time(fc), get_duration(fc))
 
 """
-    get_time_duration(file::String) -> (DateTime, Millisecond)
+    get_time_duration(file::String) -> (DateTime, Microsecond)
 
 Return the starting date & time as well as the duration of the video `file`. Note that if the starting date & time are missing, this function will return the Unix epoch (00:00 1st January 1970).
 """

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -128,6 +128,6 @@ println(stderr, "Tesing reading of video duration and date/datetime...")
 # tesing the duration and date & time functions:
 println(stderr, "   Testing annie_oakley.ogg...")
 file = joinpath(videodir, "annie_oakley.ogg")
-@test VideoIO.get_duration(file) == Dates.Millisecond(24224200)
+@test VideoIO.get_duration(file) == Dates.Microsecond(24224200)
 @test VideoIO.get_start_time(file) == DateTime(1970, 1, 1)
-@test VideoIO.get_time_duration(file) == (DateTime(1970, 1, 1), Dates.Millisecond(24224200))
+@test VideoIO.get_time_duration(file) == (DateTime(1970, 1, 1), Dates.Microsecond(24224200))


### PR DESCRIPTION
The correct duration of the "annie_oakley.ogg" movie is 24224200 **microsecond** (24.2242 seconds), not milliseconds. Otherwise it would have been 6 hours and 43 minutes and 44.2 seconds long..!