### PR TITLE
Add tests for executables (ffmpeg & ffprobe)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ addons:
   apt:
     packages:
     - imagemagick   
-cache:
-    directories:
-     - /home/travis/build/JuliaIO/VideoIO.jl/src/../videos/
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ sudo: false
 addons:
   apt:
     packages:
-    - imagemagick
-
+    - imagemagick   
+cache:
+    directories:
+     - /home/travis/build/JuliaIO/VideoIO.jl/src/../videos/
 os:
   - linux
   - osx

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -27,7 +27,6 @@ include("testvideos.jl")
 using .TestVideos
 
 if Sys.islinux()
-    ENV["LD_LIBRARY_PATH"] = joinpath(dirname(dirname(pathof(VideoIO))),"deps/usr/bin/")
     import Glob
     function init_camera_devices()
         append!(CAMERA_DEVICES, Glob.glob("video*", "/dev"))
@@ -40,7 +39,6 @@ if Sys.islinux()
 end
 
 if Sys.iswindows()
-    ENV["PATH"] = joinpath(dirname(dirname(pathof(VideoIO))),"deps/usr/bin/")
     function init_camera_devices()
         append!(CAMERA_DEVICES, get_camera_devices(ffmpeg, "dshow", "dummy"))
         DEFAULT_CAMERA_FORMAT[] = AVFormat.av_find_input_format("dshow")
@@ -55,7 +53,6 @@ if Sys.iswindows()
 end
 
 if Sys.isapple()
-    ENV["DYLD_LIBRARY_PATH"] = joinpath(dirname(dirname(pathof(VideoIO))),"deps/usr/bin/")
     function init_camera_devices()
         try
             append!(CAMERA_DEVICES, get_camera_devices(ffmpeg, "avfoundation", "\"\""))

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -93,20 +93,10 @@ end
 function __init__()
     # Always check your dependencies from `deps.jl`
     # TODO remove uncessary ENV["LD_LIBRARY_PATH"] from check_deps, so that
-    # it doesn't mess with LD_LIBRARY_PATH
+    # it doesn't mess with LD_LIBRARY_PATH, which was causing CI download issues due to issues with julia's curl
     # since check_deps is optional, I hope this is ok for now
     
-    Sys.islinux() && (pathvar = "LD_LIBRARY_PATH")
-    Sys.iswindows() && (pathvar = "PATH")
-    Sys.isapple() && (pathvar = "DYLD_LIBRARY_PATH")
-
-    libpaths = split(get(ENV, pathvar, ""), ":")
-    if !(libpath in libpaths)
-        push!(libpaths, libpath)
-    end
-    ENV[pathvar] = join(filter(!isempty, libpaths), ":")
-    
-    check_deps()
+    #check_deps()
     
     read_packet[] = @cfunction(_read_packet, Cint, (Ptr{AVInput}, Ptr{UInt8}, Cint))
 

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -26,6 +26,8 @@ include("avio.jl")
 include("testvideos.jl")
 using .TestVideos
 
+libpath = joinpath(@__DIR__, "..", "deps", "usr", "bin")
+
 if Sys.islinux()
     import Glob
     function init_camera_devices()

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -94,7 +94,8 @@ function __init__()
     # it doesn't mess with LD_LIBRARY_PATH
     # since check_deps is optional, I hope this is ok for now
 
-    # check_deps()
+    check_deps()
+    
     read_packet[] = @cfunction(_read_packet, Cint, (Ptr{AVInput}, Ptr{UInt8}, Cint))
 
     av_register_all()

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -27,6 +27,7 @@ include("testvideos.jl")
 using .TestVideos
 
 if Sys.islinux()
+    ENV["LD_LIBRARY_PATH"] = joinpath(dirname(dirname(pathof(VideoIO))),"deps/usr/bin/")
     import Glob
     function init_camera_devices()
         append!(CAMERA_DEVICES, Glob.glob("video*", "/dev"))
@@ -39,6 +40,7 @@ if Sys.islinux()
 end
 
 if Sys.iswindows()
+    ENV["PATH"] = joinpath(dirname(dirname(pathof(VideoIO))),"deps/usr/bin/")
     function init_camera_devices()
         append!(CAMERA_DEVICES, get_camera_devices(ffmpeg, "dshow", "dummy"))
         DEFAULT_CAMERA_FORMAT[] = AVFormat.av_find_input_format("dshow")
@@ -53,6 +55,7 @@ if Sys.iswindows()
 end
 
 if Sys.isapple()
+    ENV["DYLD_LIBRARY_PATH"] = joinpath(dirname(dirname(pathof(VideoIO))),"deps/usr/bin/")
     function init_camera_devices()
         try
             append!(CAMERA_DEVICES, get_camera_devices(ffmpeg, "avfoundation", "\"\""))

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -640,15 +640,8 @@ if have_avdevice()
     function get_camera_devices(ffmpeg, idev, idev_name)
         camera_devices = String[]
 
-        read_vid_devs = false
-        out = Pipe()
-        err = Pipe()
-        p = Base.open(pipeline(ignorestatus(`$ffmpeg -list_devices true -f $idev -i $idev_name`), stdout=out, stderr=err))
-        close(out.in); close(err.in)
-        err_s = readlines(err)
-        out_s = readlines(out)
-
-        lines = length(out_s) > length(err_s) ? out_s : err_s
+        read_vid_devs = false        
+        lines = execoutput(`$ffmpeg -list_devices true -f $idev -i $idev_name`)
 
         for line in lines
             if occursin("video devices",line)

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,9 +1,9 @@
 ## convenient way to get library information
 using BinaryProvider
 
-Sys.islinux() && ENV["LD_LIBRARY_PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin")
-Sys.iswindows() && ENV["PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin")
-Sys.isapple() && ENV["DYLD_LIBRARY_PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin")
+Sys.islinux() && (ENV["LD_LIBRARY_PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin"))
+Sys.iswindows() && (ENV["PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin"))
+Sys.isapple() && (ENV["DYLD_LIBRARY_PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin"))
 
 # Load in `deps.jl`, complaining if it does not exist
 const depsjl_path = joinpath(@__DIR__, "..", "deps", "deps.jl")

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,10 +1,6 @@
 ## convenient way to get library information
 using BinaryProvider
 
-Sys.islinux() && (ENV["LD_LIBRARY_PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin"))
-Sys.iswindows() && (ENV["PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin"))
-Sys.isapple() && (ENV["DYLD_LIBRARY_PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin"))
-
 # Load in `deps.jl`, complaining if it does not exist
 const depsjl_path = joinpath(@__DIR__, "..", "deps", "deps.jl")
 if !isfile(depsjl_path)

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,6 +1,10 @@
 ## convenient way to get library information
 using BinaryProvider
 
+Sys.islinux() && ENV["LD_LIBRARY_PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin")
+Sys.iswindows() && ENV["PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin")
+Sys.isapple() && ENV["DYLD_LIBRARY_PATH"] = joinpath(@__DIR__, "..", "deps", "usr", "bin")
+
 # Load in `deps.jl`, complaining if it does not exist
 const depsjl_path = joinpath(@__DIR__, "..", "deps", "deps.jl")
 if !isfile(depsjl_path)

--- a/src/util.jl
+++ b/src/util.jl
@@ -27,3 +27,11 @@ function av_pointer_to_field(s::Ptr{T}, name::Symbol) where T
 end
 
 av_pointer_to_field(s::Array, name::Symbol) = av_pointer_to_field(pointer(s), name)
+
+function execoutput(exec::Cmd)
+    out = Pipe(); err = Pipe()
+    p = Base.open(pipeline(ignorestatus(exec), stdout=out, stderr=err))
+    close(out.in); close(err.in)
+    err_s = readlines(err); out_s = readlines(out)
+    return (length(out_s) > length(err_s)) ? out_s : err_s
+end

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -13,12 +13,16 @@ swapext(f, new_ext) = "$(splitext(f)[1])$new_ext"
 
 # tesing that the executables run by testing the standard first line output
 println(stderr, "Tesing ffmpeg executable...")
-out = VideoIO.execoutput(`$(VideoIO.ffmpeg)`)
-@test occursin("ffmpeg version ",out[1])
+withenv("PATH" => VideoIO.libpath, "LD_LIBRARY_PATH" => VideoIO.libpath, "DYLD_LIBRARY_PATH" => VideoIO.libpath) do
+    out = VideoIO.execoutput(`$(VideoIO.ffmpeg)`)
+    @test occursin("ffmpeg version ",out[1])
+end
 
 println(stderr, "Tesing ffprobe executable...")
-out = VideoIO.execoutput(`$(VideoIO.ffprobe)`)
-@test occursin("ffprobe version ",out[1])
+withenv("PATH" => VideoIO.libpath, "LD_LIBRARY_PATH" => VideoIO.libpath, "DYLD_LIBRARY_PATH" => VideoIO.libpath) do
+    out = VideoIO.execoutput(`$(VideoIO.ffprobe)`)
+    @test occursin("ffprobe version ",out[1])
+end
 
 println(stderr, "Testing file reading...")
 

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -11,11 +11,14 @@ VideoIO.TestVideos.download_all()
 
 swapext(f, new_ext) = "$(splitext(f)[1])$new_ext"
 
-# tesing that the executables run
+# tesing that the executables run by testing the standard first line output
 println(stderr, "Tesing ffmpeg executable...")
-@test occursin("ffmpeg version ",VideoIO.execoutput(`$(VideoIO.ffmpeg)`)[1])
+out = VideoIO.execoutput(`$(VideoIO.ffmpeg)`)
+@test occursin("ffmpeg version ",out[1])
+
 println(stderr, "Tesing ffprobe executable...")
-@test occursin("ffprobe version ",VideoIO.execoutput(`$(VideoIO.ffprobe)`)[1])
+out = VideoIO.execoutput(`$(VideoIO.ffprobe)`)
+@test occursin("ffprobe version ",out[1])
 
 println(stderr, "Testing file reading...")
 

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -11,6 +11,12 @@ VideoIO.TestVideos.download_all()
 
 swapext(f, new_ext) = "$(splitext(f)[1])$new_ext"
 
+# tesing that the executables run
+println(stderr, "Tesing ffmpeg executable...")
+@test occursin("ffmpeg version ",VideoIO.execoutput(`$(VideoIO.ffmpeg)`)[1])
+println(stderr, "Tesing ffprobe executable...")
+@test occursin("ffprobe version ",VideoIO.execoutput(`$(VideoIO.ffprobe)`)[1])
+
 println(stderr, "Testing file reading...")
 
 @noinline function isblank(img)

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -13,16 +13,12 @@ swapext(f, new_ext) = "$(splitext(f)[1])$new_ext"
 
 # tesing that the executables run by testing the standard first line output
 println(stderr, "Tesing ffmpeg executable...")
-withenv("PATH" => VideoIO.libpath, "LD_LIBRARY_PATH" => VideoIO.libpath, "DYLD_LIBRARY_PATH" => VideoIO.libpath) do
-    out = VideoIO.execoutput(`$(VideoIO.ffmpeg)`)
-    @test occursin("ffmpeg version ",out[1])
-end
+out = VideoIO.execoutput(`$(VideoIO.ffmpeg)`)
+@test occursin("ffmpeg version ",out[1])
 
 println(stderr, "Tesing ffprobe executable...")
-withenv("PATH" => VideoIO.libpath, "LD_LIBRARY_PATH" => VideoIO.libpath, "DYLD_LIBRARY_PATH" => VideoIO.libpath) do
-    out = VideoIO.execoutput(`$(VideoIO.ffprobe)`)
-    @test occursin("ffprobe version ",out[1])
-end
+out = VideoIO.execoutput(`$(VideoIO.ffprobe)`)
+@test occursin("ffprobe version ",out[1])
 
 println(stderr, "Testing file reading...")
 


### PR DESCRIPTION
With this, ffmpeg or ffprobe can be used externally like this (for instance to write a video) where the lib path for windows, linux and OSX needs to be set:
```julia
withenv("PATH" => VideoIO.libpath, "LD_LIBRARY_PATH" => VideoIO.libpath, "DYLD_LIBRARY_PATH" => VideoIO.libpath) do
    open(`$(VideoIO.ffmpeg etc. etc. fname.mpeg`, "w") do out
        for image in images
            write(out, image)
        end
    end
end
```