### PR TITLE
Tidying post BinaryProvider switch

### DIFF
--- a/src/ffmpeg/AVUtil/src/AVUtil.jl
+++ b/src/ffmpeg/AVUtil/src/AVUtil.jl
@@ -4,6 +4,7 @@ module AVUtil
 
   include(w("LIBAVUTIL.jl"))
 
-  Base.zero(::Type{AVRational}) = AVRational(0, 1)
+    #If AVUtil v55 is needed, this will need to be added back
+  #Base.zero(::Type{AVRational}) = AVRational(0, 1)
 
 end


### PR DESCRIPTION
There are some redefinitions occurring due to back-support of prior ffmpeg versions.

Given we're now fixed to ffmpeg 4.1, shall we remove all the older version support?
If not we can keep this as a simple PR to remove that redefinition