### PR TITLE
fix GRAY8 lossless encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,28 +143,29 @@ Optional fields can be found [here](https://ffmpeg.org/doxygen/4.1/structAVCodec
 
 A few helpful presets for h264:
 
+- Perceptual compression, h264 default - Best for most cases:
+```AVCodecContextProperties = [:priv_data => ("crf"=>"23","preset"=>"medium")]```
 - Lossless compression - Fastest, largest file size:
 ```AVCodecContextProperties = [:priv_data => ("crf"=>"0","preset"=>"ultrafast")]```
 - Lossless compression - Slowest, smallest file size:
 ```AVCodecContextProperties = [:priv_data => ("crf"=>"0","preset"=>"ultraslow")]```
-- Perceptual compression, h264 default (as per docs):
-```AVCodecContextProperties = [:priv_data => ("crf"=>"23","preset"=>"medium")]```
 - Direct control of bitrate and frequency of intra frames (every 10):
 ```AVCodecContextProperties = [:bit_rate => 400000,:gop_size = 10,:max_b_frames=1]```
 
 Encoding of the following image element color types currently supported:
-- UInt8
-- Gray{N0f8}
-- RGB{N0f8}
+- `UInt8`
+- `Gray{N0f8}`
+- `RGB{N0f8}`
 
 
-### RGB encoding
-If lossless encoding of `RGB{N0f8}`` or `Gray{N0f8}`` is required, _true_ lossless
-requires using libx264rgb, to avoid the lossy RGB->YUV420 conversion and GRAY8
-color_range compression in libx264. That's achieved with
-codec_name="libx264rgb" and "crf" => "0" in the above example, but is typically
-only useful for data storage given that even VLC struggles playing back
-libx264rgb videos smoothly.
+### Lossless encoding
+If lossless encoding of `RGB{N0f8}` is required, _true_ lossless
+requires using `codec_name = "libx264rgb"`, to avoid the lossy RGB->YUV420 conversion,
+and `"crf" => "0"`.
+
+If lossless encoding of `Gray{N0f8}` or `UInt8` is required, `"crf" => "0"` should be
+set, as well as `:color_range=>2` to ensure full 8-bit pixel color representation.
+i.e. `[:color_range=>2, :priv_data => ("crf"=>"0","preset"=>"medium")]`
 
 
 Low Level Interface

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -56,7 +56,7 @@ if Sys.islinux()
         "https://github.com/staticfloat/OggBuilder/releases/download/v1.3.3-7/build_Ogg.v1.3.3.jl",
         "https://github.com/JuliaIO/LibVorbisBuilder/releases/download/v1.3.6/build_libvorbis.v1.3.6.jl",
         "https://github.com/jpsamaroo/LibVPXBuilder/releases/download/v5.0.0/build_LibVPX.v5.0.0.jl",
-        "https://github.com/jpsamaroo/x264Builder/releases/download/v2018.2.12-noyasm/build_x264Builder.v2018.2.12-pre-noyasm.jl"
+        "https://github.com/ianshmean/x264Builder/releases/download/v2019.5.25-noyasm/build_x264Builder.v2019.5.25-noyasm.jl"
     ]
 
     for dependency in dependencies

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -31,7 +31,7 @@ download_info = Dict(
     #Linux(:powerpc64le, :glibc) => ("$bin_prefix/ffmpeg-$v-powerpc64le-linux-gnu.tar.gz", ""),
     #Linux(:i686, :glibc)    => ("$bin_prefix/ffmpeg-$v-i686-linux-gnu.tar.gz", ""),
     #Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu-full.tar.gz", "e1544d62d65368e6ed7c5910d1695e9b8957ea7793d9afc4fdd8671e86cb4fb0"),
-    Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu.tar.gz", "7d1199e95f8a81b6e3fa6fd6584ca6f419847f6d4f5a5dc83656cd46e84a51fb"),
+    Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu.tar.gz", "683249e7450a18a13f7a896b4abd6b92abff77ddeb3640ad10fe48bb7723f4fc"),
 
     #Linux(:aarch64, :musl)  => ("$bin_prefix/ffmpeg-$v-aarch64-linux-musl.tar.gz", ""),
     #Linux(:armv7l, :musl)   => ("$bin_prefix/ffmpeg-$v-arm-linux-musleabihf.tar.gz", ""),

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -30,7 +30,8 @@ download_info = Dict(
     #Linux(:armv7l, :glibc)  => ("$bin_prefix/ffmpeg-$v-arm-linux-gnueabihf.tar.gz", ""),
     #Linux(:powerpc64le, :glibc) => ("$bin_prefix/ffmpeg-$v-powerpc64le-linux-gnu.tar.gz", ""),
     #Linux(:i686, :glibc)    => ("$bin_prefix/ffmpeg-$v-i686-linux-gnu.tar.gz", ""),
-    Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu-full.tar.gz", "e1544d62d65368e6ed7c5910d1695e9b8957ea7793d9afc4fdd8671e86cb4fb0"),
+    #Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu-full.tar.gz", "e1544d62d65368e6ed7c5910d1695e9b8957ea7793d9afc4fdd8671e86cb4fb0"),
+    Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu.tar.gz", "7d1199e95f8a81b6e3fa6fd6584ca6f419847f6d4f5a5dc83656cd46e84a51fb"),
 
     #Linux(:aarch64, :musl)  => ("$bin_prefix/ffmpeg-$v-aarch64-linux-musl.tar.gz", ""),
     #Linux(:armv7l, :musl)   => ("$bin_prefix/ffmpeg-$v-arm-linux-musleabihf.tar.gz", ""),

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -31,7 +31,7 @@ download_info = Dict(
     #Linux(:powerpc64le, :glibc) => ("$bin_prefix/ffmpeg-$v-powerpc64le-linux-gnu.tar.gz", ""),
     #Linux(:i686, :glibc)    => ("$bin_prefix/ffmpeg-$v-i686-linux-gnu.tar.gz", ""),
     #Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu-full.tar.gz", "e1544d62d65368e6ed7c5910d1695e9b8957ea7793d9afc4fdd8671e86cb4fb0"),
-    Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu.tar.gz", "683249e7450a18a13f7a896b4abd6b92abff77ddeb3640ad10fe48bb7723f4fc"),
+    Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu-full.tar.gz", "683249e7450a18a13f7a896b4abd6b92abff77ddeb3640ad10fe48bb7723f4fc"),
 
     #Linux(:aarch64, :musl)  => ("$bin_prefix/ffmpeg-$v-aarch64-linux-musl.tar.gz", ""),
     #Linux(:armv7l, :musl)   => ("$bin_prefix/ffmpeg-$v-arm-linux-musleabihf.tar.gz", ""),

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -30,7 +30,6 @@ download_info = Dict(
     #Linux(:armv7l, :glibc)  => ("$bin_prefix/ffmpeg-$v-arm-linux-gnueabihf.tar.gz", ""),
     #Linux(:powerpc64le, :glibc) => ("$bin_prefix/ffmpeg-$v-powerpc64le-linux-gnu.tar.gz", ""),
     #Linux(:i686, :glibc)    => ("$bin_prefix/ffmpeg-$v-i686-linux-gnu.tar.gz", ""),
-    #Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu-full.tar.gz", "e1544d62d65368e6ed7c5910d1695e9b8957ea7793d9afc4fdd8671e86cb4fb0"),
     Linux(:x86_64, :glibc)  => ("$bin_prefix/ffmpeg-$v-86_64-linux-gnu-full.tar.gz", "683249e7450a18a13f7a896b4abd6b92abff77ddeb3640ad10fe48bb7723f4fc"),
 
     #Linux(:aarch64, :musl)  => ("$bin_prefix/ffmpeg-$v-aarch64-linux-musl.tar.gz", ""),

--- a/examples/lossless_video_encoding_testing.jl
+++ b/examples/lossless_video_encoding_testing.jl
@@ -59,10 +59,14 @@ df_noise[:fps] = length(imgstack_gray_noise)./df_noise[:time]
 df_testvid[:fps] = length(imgstack_gray_testvid)./df_testvid[:time]
 df_ladybird[:fps] = length(imgstack_gray_ladybird)./df_ladybird[:time]
 
+using Statistics
 df_noise_summary = by(df_noise, :preset, identical = :identical => minimum, fps_mean = :fps => mean, fps_std = :fps => std, filesize_perc_mean = :filesize_perc => mean,filesize_perc_std = :filesize_perc => std)
 df_testvid_summary = by(df_testvid, :preset, identical = :identical => minimum, fps_mean = :fps => mean, fps_std = :fps => std, filesize_perc_mean = :filesize_perc => mean,filesize_perc_std = :filesize_perc => std)
 df_ladybird_summary = by(df_ladybird, :preset, identical = :identical => minimum, fps_mean = :fps => mean, fps_std = :fps => std, filesize_perc_mean = :filesize_perc => mean,filesize_perc_std = :filesize_perc => std)
 
+@show df_noise_summary
+@show df_testvid_summary
+@show df_ladybird_summary
 # HISTOGRAM COMPARISON
 # using PyPlot, ImageCore
 # figure()

--- a/examples/lossless_video_encoding_testing.jl
+++ b/examples/lossless_video_encoding_testing.jl
@@ -26,7 +26,6 @@ function testvideocomp!(df,preset,imgstack_gray)
 end
 
 imgstack_gray_noise = map(x->rand(Gray{N0f8},1280,720),1:1000)
-noise_raw_size = size(imgstack_gray_noise,1) * size(imgstack_gray_noise,2) * length(imgstack_gray_noise) * 8
 
 f = openvideo(createtestvideo())
 imgstack = []
@@ -34,7 +33,6 @@ while !eof(f)
     push!(imgstack,read(f))
 end
 imgstack_gray_testvid = map(x->convert.(Gray{N0f8},x),imgstack)
-testvid_raw_size = size(imgstack_gray_testvid,1) * size(imgstack_gray_testvid,2) * length(imgstack_gray_testvid) * 8
 
 f = openvideo("videos/ladybird.mp4")
 imgstack = []
@@ -42,7 +40,6 @@ while !eof(f)
     push!(imgstack,read(f))
 end
 imgstack_gray_ladybird = map(x->convert.(Gray{N0f8},x),imgstack)
-ladybird_raw_size = size(imgstack_gray_ladybird,1) * size(imgstack_gray_ladybird,2) * length(imgstack_gray_ladybird) * 8
 
 df_noise = DataFrame(preset=[],filesize=[],time=[],identical=[])
 df_testvid = DataFrame(preset=[],filesize=[],time=[],identical=[])
@@ -57,6 +54,11 @@ for preset in ["ultrafast","superfast","veryfast","faster","fast","medium","slow
         testvideocomp!(df_ladybird,preset,imgstack_gray_ladybird)
     end
 end
+
+noise_raw_size = size(imgstack_gray_noise[1],1) * size(imgstack_gray_noise[1],2) * length(imgstack_gray_noise)
+testvid_raw_size = size(imgstack_gray_testvid[1],1) * size(imgstack_gray_testvid[1],2) * length(imgstack_gray_testvid)
+ladybird_raw_size = size(imgstack_gray_ladybird[1],1) * size(imgstack_gray_ladybird[1],2) * length(imgstack_gray_ladybird)
+
 df_noise[:filesize_perc] = 100*(df_noise[:filesize]./noise_raw_size)
 df_testvid[:filesize_perc] = 100*(df_testvid[:filesize]./testvid_raw_size)
 df_ladybird[:filesize_perc] = 100*(df_ladybird[:filesize]./ladybird_raw_size)
@@ -73,7 +75,53 @@ df_ladybird_summary = by(df_ladybird, :preset, identical = :identical => minimum
 @show df_testvid_summary
 @show df_ladybird_summary
 
-# HISTOGRAM COMPARISON
+### Results (generated 2019-05-29 on a 2019 Macbook Pro)
+#=
+df_noise_summary = 9×6 DataFrame
+│ Row │ preset    │ identical │ fps_mean │ fps_std │ filesize_perc_mean │ filesize_perc_std │
+│     │ Any       │ Bool      │ Float64  │ Float64 │ Float64            │ Float64           │
+├─────┼───────────┼───────────┼──────────┼─────────┼────────────────────┼───────────────────┤
+│ 1   │ ultrafast │ true      │ 92.5769  │ 8.40224 │ 156.444            │ 0.0               │
+│ 2   │ superfast │ true      │ 62.3509  │ 1.19652 │ 144.019            │ 0.0               │
+│ 3   │ veryfast  │ true      │ 59.9182  │ 1.77294 │ 144.019            │ 0.0               │
+│ 4   │ faster    │ true      │ 60.3482  │ 2.32679 │ 144.02             │ 0.0               │
+│ 5   │ fast      │ true      │ 149.169  │ 1.56068 │ 100.784            │ 0.0               │
+│ 6   │ medium    │ true      │ 146.141  │ 3.41282 │ 100.784            │ 0.0               │
+│ 7   │ slow      │ true      │ 147.214  │ 1.23929 │ 100.784            │ 0.0               │
+│ 8   │ slower    │ true      │ 138.808  │ 2.553   │ 100.784            │ 0.0               │
+│ 9   │ veryslow  │ true      │ 132.505  │ 3.28558 │ 100.784            │ 0.0               │
+
+df_testvid_summary = 9×6 DataFrame
+│ Row │ preset    │ identical │ fps_mean │ fps_std │ filesize_perc_mean │ filesize_perc_std │
+│     │ Any       │ Bool      │ Float64  │ Float64 │ Float64            │ Float64           │
+├─────┼───────────┼───────────┼──────────┼─────────┼────────────────────┼───────────────────┤
+│ 1   │ ultrafast │ true      │ 228.166  │ 75.1439 │ 4.80392            │ 0.0               │
+│ 2   │ superfast │ true      │ 239.73   │ 54.2033 │ 3.62199            │ 0.0               │
+│ 3   │ veryfast  │ true      │ 197.506  │ 13.1121 │ 3.59901            │ 0.0               │
+│ 4   │ faster    │ true      │ 174.174  │ 18.0316 │ 3.60282            │ 0.0               │
+│ 5   │ fast      │ true      │ 235.181  │ 7.40358 │ 3.44104            │ 0.0               │
+│ 6   │ medium    │ true      │ 219.654  │ 3.27445 │ 3.40832            │ 0.0               │
+│ 7   │ slow      │ true      │ 171.337  │ 3.92415 │ 3.33917            │ 0.0               │
+│ 8   │ slower    │ true      │ 105.24   │ 6.59151 │ 3.25774            │ 5.43896e-16       │
+│ 9   │ veryslow  │ true      │ 63.1136  │ 2.47291 │ 3.2219             │ 0.0               │
+
+df_ladybird_summary = 9×6 DataFrame
+│ Row │ preset    │ identical │ fps_mean │ fps_std  │ filesize_perc_mean │ filesize_perc_std │
+│     │ Any       │ Bool      │ Float64  │ Float64  │ Float64            │ Float64           │
+├─────┼───────────┼───────────┼──────────┼──────────┼────────────────────┼───────────────────┤
+│ 1   │ ultrafast │ true      │ 176.787  │ 36.5227  │ 12.2293            │ 0.0               │
+│ 2   │ superfast │ true      │ 135.925  │ 7.04431  │ 10.3532            │ 0.0               │
+│ 3   │ veryfast  │ true      │ 117.115  │ 1.28102  │ 10.1954            │ 0.0               │
+│ 4   │ faster    │ true      │ 94.39    │ 3.48494  │ 9.85604            │ 0.0               │
+│ 5   │ fast      │ true      │ 69.657   │ 1.61004  │ 9.62724            │ 0.0               │
+│ 6   │ medium    │ true      │ 54.9621  │ 0.568074 │ 9.51032            │ 0.0               │
+│ 7   │ slow      │ true      │ 37.8888  │ 1.27484  │ 9.33622            │ 0.0               │
+│ 8   │ slower    │ true      │ 20.1112  │ 1.04282  │ 9.25529            │ 0.0               │
+│ 9   │ veryslow  │ true      │ 10.0016  │ 0.473213 │ 9.24999            │ 0.0               │
+=#
+
+
+# HISTOGRAM COMPARISON - useful for diagnosing range compression
 # using PyPlot, ImageCore
 # figure()
 # hist(rawview(channelview(imgstack_gray_copy[1]))[:],0:256,label="copy")

--- a/examples/lossless_video_encoding_testing.jl
+++ b/examples/lossless_video_encoding_testing.jl
@@ -26,18 +26,23 @@ function testvideocomp!(df,preset,imgstack_gray)
 end
 
 imgstack_gray_noise = map(x->rand(Gray{N0f8},1280,720),1:1000)
+noise_raw_size = size(imgstack_gray_noise,1) * size(imgstack_gray_noise,2) * length(imgstack_gray_noise) * 8
+
 f = openvideo(createtestvideo())
 imgstack = []
 while !eof(f)
     push!(imgstack,read(f))
 end
 imgstack_gray_testvid = map(x->convert.(Gray{N0f8},x),imgstack)
+testvid_raw_size = size(imgstack_gray_testvid,1) * size(imgstack_gray_testvid,2) * length(imgstack_gray_testvid) * 8
+
 f = openvideo("videos/ladybird.mp4")
 imgstack = []
 while !eof(f)
     push!(imgstack,read(f))
 end
 imgstack_gray_ladybird = map(x->convert.(Gray{N0f8},x),imgstack)
+ladybird_raw_size = size(imgstack_gray_ladybird,1) * size(imgstack_gray_ladybird,2) * length(imgstack_gray_ladybird) * 8
 
 df_noise = DataFrame(preset=[],filesize=[],time=[],identical=[])
 df_testvid = DataFrame(preset=[],filesize=[],time=[],identical=[])
@@ -52,9 +57,9 @@ for preset in ["ultrafast","superfast","veryfast","faster","fast","medium","slow
         testvideocomp!(df_ladybird,preset,imgstack_gray_ladybird)
     end
 end
-df_noise[:filesize_perc] = 100*(df_noise[:filesize]./df_noise[:filesize][1])
-df_testvid[:filesize_perc] = 100*(df_testvid[:filesize]./df_testvid[:filesize][1])
-df_ladybird[:filesize_perc] = 100*(df_ladybird[:filesize]./df_ladybird[:filesize][1])
+df_noise[:filesize_perc] = 100*(df_noise[:filesize]./noise_raw_size)
+df_testvid[:filesize_perc] = 100*(df_testvid[:filesize]./testvid_raw_size)
+df_ladybird[:filesize_perc] = 100*(df_ladybird[:filesize]./ladybird_raw_size)
 df_noise[:fps] = length(imgstack_gray_noise)./df_noise[:time]
 df_testvid[:fps] = length(imgstack_gray_testvid)./df_testvid[:time]
 df_ladybird[:fps] = length(imgstack_gray_ladybird)./df_ladybird[:time]
@@ -67,6 +72,7 @@ df_ladybird_summary = by(df_ladybird, :preset, identical = :identical => minimum
 @show df_noise_summary
 @show df_testvid_summary
 @show df_ladybird_summary
+
 # HISTOGRAM COMPARISON
 # using PyPlot, ImageCore
 # figure()

--- a/examples/lossless_video_encoding_testing.jl
+++ b/examples/lossless_video_encoding_testing.jl
@@ -1,0 +1,71 @@
+
+using VideoIO, ColorTypes, FixedPointNumbers, DataFrames
+
+function createtestvideo(;filename::String="$(tempname()).mp4",duration::Real=5,
+    width::Int64=1280,height::Int64=720,framerate::Real=30,testtype::String="testsrc2",
+    encoder::String="libx264rgb")
+    withenv("PATH" => VideoIO.libpath, "LD_LIBRARY_PATH" => VideoIO.libpath, "DYLD_LIBRARY_PATH" => VideoIO.libpath) do
+        VideoIO.collectexecoutput(`$(VideoIO.ffmpeg) -y -f lavfi -i
+            $testtype=duration=$duration:size=$(width)x$(height):rate=$framerate
+            -c:v $encoder -preset slow -crf 0 -c:a copy $filename`)
+    end
+    return filename
+end
+
+function testvideocomp!(df,preset,imgstack_gray)
+    t = @elapsed encodevideo("video.mp4",imgstack_gray,framerate=30,codec_name = "libx264",
+        AVCodecContextProperties=[:color_range => 2, :priv_data => ("crf"=>"0","preset"=>preset)])
+    fs = filesize("video.mp4")
+    f = openvideo("video.mp4",target_format=VideoIO.AV_PIX_FMT_GRAY8)
+    imgstack_gray_copy = []
+    while !eof(f)
+        push!(imgstack_gray_copy,read(f))
+    end
+    identical = !any(.!(imgstack_gray .== imgstack_gray_copy))
+    push!(df,[preset,fs,t,identical])
+end
+
+imgstack_gray_noise = map(x->rand(Gray{N0f8},1280,720),1:1000)
+f = openvideo(createtestvideo())
+imgstack = []
+while !eof(f)
+    push!(imgstack,read(f))
+end
+imgstack_gray_testvid = map(x->convert.(Gray{N0f8},x),imgstack)
+f = openvideo("videos/ladybird.mp4")
+imgstack = []
+while !eof(f)
+    push!(imgstack,read(f))
+end
+imgstack_gray_ladybird = map(x->convert.(Gray{N0f8},x),imgstack)
+
+df_noise = DataFrame(preset=[],filesize=[],time=[],identical=[])
+df_testvid = DataFrame(preset=[],filesize=[],time=[],identical=[])
+df_ladybird = DataFrame(preset=[],filesize=[],time=[],identical=[])
+for preset in ["ultrafast","superfast","veryfast","faster","fast","medium","slow",
+"slower","veryslow"]
+    @show preset
+    for rep in 1:3
+        @show rep
+        testvideocomp!(df_noise,preset,imgstack_gray_noise)
+        testvideocomp!(df_testvid,preset,imgstack_gray_testvid)
+        testvideocomp!(df_ladybird,preset,imgstack_gray_ladybird)
+    end
+end
+df_noise[:filesize_perc] = 100*(df_noise[:filesize]./df_noise[:filesize][1])
+df_testvid[:filesize_perc] = 100*(df_testvid[:filesize]./df_testvid[:filesize][1])
+df_ladybird[:filesize_perc] = 100*(df_ladybird[:filesize]./df_ladybird[:filesize][1])
+df_noise[:fps] = length(imgstack_gray_noise)./df_noise[:time]
+df_testvid[:fps] = length(imgstack_gray_testvid)./df_testvid[:time]
+df_ladybird[:fps] = length(imgstack_gray_ladybird)./df_ladybird[:time]
+
+df_noise_summary = by(df_noise, :preset, identical = :identical => minimum, fps_mean = :fps => mean, fps_std = :fps => std, filesize_perc_mean = :filesize_perc => mean,filesize_perc_std = :filesize_perc => std)
+df_testvid_summary = by(df_testvid, :preset, identical = :identical => minimum, fps_mean = :fps => mean, fps_std = :fps => std, filesize_perc_mean = :filesize_perc => mean,filesize_perc_std = :filesize_perc => std)
+df_ladybird_summary = by(df_ladybird, :preset, identical = :identical => minimum, fps_mean = :fps => mean, fps_std = :fps => std, filesize_perc_mean = :filesize_perc => mean,filesize_perc_std = :filesize_perc => std)
+
+# HISTOGRAM COMPARISON
+# using PyPlot, ImageCore
+# figure()
+# hist(rawview(channelview(imgstack_gray_copy[1]))[:],0:256,label="copy")
+# hist(rawview(channelview(imgstack_gray[1]))[:],0:256,label="original")
+# legend()

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -146,14 +146,14 @@ end
     end
     @testset "Lossless Grayscale encoding" begin
         file_lossless_gray_copy = joinpath(videodir, "annie_oakley_lossless_gray.mp4")
-        prop = [:priv_data => ("crf"=>"0","preset"=>"medium")]
-        codec_name="libx264rgb"
+        prop = [:color_range=>2, :priv_data => ("crf"=>"0","preset"=>"medium")]
+        codec_name="libx264"
         VideoIO.encodevideo(file_lossless_gray_copy,imgstack_gray,codec_name=codec_name,AVCodecContextProperties=prop, silent=true)
 
-        fcopy = VideoIO.openvideo(file_lossless_gray_copy)
+        fcopy = VideoIO.openvideo(file_lossless_gray_copy,target_format=VideoIO.AV_PIX_FMT_GRAY8)
         imgstack_gray_copy = []
         while !eof(fcopy)
-            push!(imgstack_gray_copy,convert.(Gray{N0f8},collect(read(fcopy))))
+            push!(imgstack_gray_copy,collect(read(fcopy)))
         end
         close(f)
         @test eltype(imgstack_gray) == eltype(imgstack_gray_copy)


### PR DESCRIPTION
Using `:color_range=>2` prevents the clamping of the GRAY8 pixel value range from 0-255 to 16-235