### PR TITLE
Add Cirrus CI script

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,18 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+task:
+  name: FreeBSD
+  env:
+    matrix:
+      - JULIA_VERSION: 1.0
+      - JULIA_VERSION: 1.1
+      - JULIA_VERSION: 1.2
+      - JULIA_VERSION: nightly
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - cirrusjl test
+  coverage_script:
+    - cirrusjl coverage codecov coveralls


### PR DESCRIPTION
If you can enable https://github.com/marketplace/cirrus-ci on this repository (or perhaps all repos of the organisation), this PR allows testing on FreeBSD.  Note that failures on Julia 1.2 and nightly are expected

@ianshmean: probably you'll want to rebase #176 on master after this is merged