### PR TITLE
Add `gettime()` to read approximate current position in seconds

### DIFF
--- a/src/avio.jl
+++ b/src/avio.jl
@@ -482,9 +482,9 @@ end
 Return timestamp of current position in seconds.
 """
 function gettime(s::VideoReader;video_stream::Integer=1)
-    stream = s.avin.video_info[video_stream].stream
+    time_base = stream.time_base
     frameindex = s.aVideoFrame[video_stream].pkt_dts   #av_frame_get_best_effort_timestamp(s.aVideoFrame)
-    return frameindex * (stream.time_base.num/stream.time_base.den)
+    return frameindex * (time_base.num/time_base.den)
 end
 
 function seek(s::VideoReader, seconds::AbstractFloat,

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -2,7 +2,7 @@
 
 import Base: read, read!, show, close, eof, isopen, seek, seekstart
 
-export read, read!, pump, openvideo, opencamera, playvideo, viewcam, play
+export read, read!, pump, openvideo, opencamera, playvideo, viewcam, play, gettime
 
 mutable struct StreamInfo
     stream_index0::Int             # zero-based
@@ -482,7 +482,7 @@ end
 Return timestamp of current position in seconds.
 """
 function gettime(s::VideoReader;video_stream::Integer=1)
-    time_base = stream.time_base
+    time_base = s.avin.video_info[video_stream].stream.time_base
     frameindex = s.aVideoFrame[video_stream].pkt_dts   #av_frame_get_best_effort_timestamp(s.aVideoFrame)
     return frameindex * (time_base.num/time_base.den)
 end

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -476,6 +476,17 @@ function seconds_to_timestamp(s::Float64, time_base::AVRational)
     return round(Int64, floor(s *  convert(Float64, time_base.den) / convert(Float64, time_base.num)))
 end
 
+"""
+    gettime(s::VideoReader;video_stream::Integer=1)
+
+Return timestamp of current position in seconds.
+"""
+function gettime(s::VideoReader;video_stream::Integer=1)
+    stream = s.avin.video_info[video_stream].stream
+    frameindex = s.aVideoFrame[video_stream].pkt_dts   #av_frame_get_best_effort_timestamp(s.aVideoFrame)
+    return frameindex * (stream.time_base.num/stream.time_base.den)
+end
+
 function seek(s::VideoReader, seconds::AbstractFloat,
               seconds_min::AbstractFloat=-1.0,  seconds_max::AbstractFloat=-1.0,
               video_stream::Integer=1, forward::Bool=false)

--- a/src/info.jl
+++ b/src/info.jl
@@ -4,12 +4,12 @@ function _get_fc(file::String) # convenience function for `get_duration` and `ge
     v = open(file)
     return unsafe_load(v.apFormatContext[1])
 end
-get_duration(fc::AVFormatContext) = Dates.Microsecond(fc.duration) # this is a bit risky: if AV_TIME_BASE ≠ 1e6 then this conversion will give false results, or if `fc.duration` is not a whole number then this will result in an InexactError. I'll add the appropriate checks if you'll tell me that either event or both are possible.
+get_duration(fc::AVFormatContext) = fc.duration / 1e6
 
 """
-    get_duration(file::String) -> Microsecond
+    get_duration(file::String) -> Float64
 
-Return the duration of the video `file` in `Microsecond`s.
+Return the duration of the video `file` in seconds (float).
 """
 get_duration(file::String) = get_duration(_get_fc(file))
 

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -200,9 +200,9 @@ end
 @testset "Reading video duration, start date, and duration" begin
     # tesing the duration and date & time functions:
     file = joinpath(videodir, "annie_oakley.ogg")
-    @test VideoIO.get_duration(file) == Dates.Microsecond(24224200)
+    @test VideoIO.get_duration(file) == 24224200/1e6
     @test VideoIO.get_start_time(file) == DateTime(1970, 1, 1)
-    @test VideoIO.get_time_duration(file) == (DateTime(1970, 1, 1), Dates.Microsecond(24224200))
+    @test VideoIO.get_time_duration(file) == (DateTime(1970, 1, 1), 24224200/1e6)
 end
 
 @testset "Lossless video encoding (read, encode, read, compare)" begin

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -100,6 +100,9 @@ end
 
             f = VideoIO.testvideo(name)
             v = VideoIO.openvideo(f)
+            
+            time_seconds = gettime(v)
+            @test time_seconds == 0
 
             if !createmode && (size(first_frame, 1) > v.height)
                 first_frame = first_frame[1+size(first_frame,1)-v.height:end,:]

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -101,7 +101,7 @@ end
             f = VideoIO.testvideo(name)
             v = VideoIO.openvideo(f)
             
-            time_seconds = gettime(v)
+            time_seconds = VideoIO.gettime(v)
             @test time_seconds == 0
 
             if !createmode && (size(first_frame, 1) > v.height)


### PR DESCRIPTION
@yakir12 Does this give what you want?

```
    gettime(s::VideoReader;video_stream::Integer=1)

Return timestamp of current position in seconds.
```

i.e.
```julia
using VideoIO
f = VideoIO.testvideo("annie_oakley")
v = openvideo(f)
@show gettime(v)
seek(v,10.0)
@show gettime(v)
seek(v,15.0)
@show gettime(v)
```
gettime(v) = 0.0
gettime(v) = 9.943266666666668
gettime(v) = 14.948266666666669
