### PR TITLE
fix build

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -53,8 +53,6 @@ for dependency in dependencies
     Mod.include(file)
 end
 
-# First, check to see if we're all satisfied
-if any(!satisfied(p; verbose=verbose) for p in products)
-    # Finally, write out a deps.jl file
-    write_deps_file(joinpath(@__DIR__, "deps.jl"), products)
-end
+
+# Finally, write out a deps.jl file
+write_deps_file(joinpath(@__DIR__, "deps.jl"), products)


### PR DESCRIPTION
this is exactly the same problem as we had with ImageMagick - the deps file only gets written if any dependency is NOT satisfied... First of all, if we build, the depsfile should always be written (and error in `write_deps_file` if something isn't satisfied), and secondly, if there is any case a depsfile shouldn't be written, it's if any dependency is not satisfied ;)