### PR TITLE
Make delete stream file optional in mux

### DIFF
--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -209,15 +209,15 @@ function finishencode!(encoder::VideoEncoder, io::IO)
 end
 
 """
-mux(srcfilename,destfilename,framerate;silent=false)
+mux(srcfilename,destfilename,framerate;silent=false,deletestream=true)
 
-Multiplex stream object into video container.
+Multiplex stream file into video container. Deletes stream file by default.
 """
-function mux(srcfilename,destfilename,framerate;silent=false)
+function mux(srcfilename,destfilename,framerate;silent=false,deletestream=true)
     muxout = FFMPEG.exe(`-y -framerate $framerate -i $srcfilename -c copy $destfilename`, collect=true)
     filter!(x->!occursin.("Timestamps are unset in a packet for stream 0.",x),muxout) #known non-bug issue with h264
     if occursin("ffmpeg version ",muxout[1]) && occursin("video:",muxout[end])
-        rm("$srcfilename")
+        deletestream && rm("$srcfilename")
         !silent && (@info "Video file saved: $(pwd())/$destfilename")
         !silent && (@info muxout[end-1])
         !silent && (@info muxout[end])


### PR DESCRIPTION
I noticed this was a bit heavy-handed, but didn't want to break things, so defaults to delete, but can be overridden