### PR TITLE
Add frame skip & frame count functions

### DIFF
--- a/docs/src/reading.md
+++ b/docs/src/reading.md
@@ -31,6 +31,22 @@ VideoIO.seek
 VideoIO.seekstart
 ```
 
+Frames can be skipped without reading frame content via `skipframe(f)` and `skipframes(f, n)`
+```@docs
+VideoIO.skipframe
+```
+```@docs
+VideoIO.skipframes
+```
+
+Total available frame count is available via `counttotalframes(f)`
+```@docs
+VideoIO.counttotalframes
+```
+
+!!! note H264 videos encoded with `crf>0` have been observed to have 4-fewer frames 
+available for reading.
+
 ### Changing the target pixel format for reading
 It can be helpful to be explicit in which pixel format you wish to read frames as.
 Here a grayscale video is read and parsed into a `Vector(Array{UInt8}}`

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -633,16 +633,20 @@ function skipframes(s::VideoReader, n::Int; throwEOF=true)
 end
 
 """
-    countframes(s::VideoReader)
+    counttotalframes(s::VideoReader)
     
-Count the number of frames remaining in the video by skipping through each frame.
+Count the total number of frames in the video by seeking to start, skipping through 
+each frame, and seeking back to the start.
 """
-function countframes(s::VideoReader)
+function counttotalframes(s::VideoReader)
+    seekstart(s)
     n = 1
     while true
-        skipframe(s, throwEOF = false) && return n
+        skipframe(s, throwEOF = false) && break
         n += 1
     end
+    seekstart(s)
+    return n
 end
 
 function eof(avin::AVInput)

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -3,6 +3,7 @@
 import Base: read, read!, show, close, eof, isopen, seek, seekstart
 
 export read, read!, pump, openvideo, opencamera, playvideo, viewcam, play, gettime
+export skipframe, skipframes, counttotalframes
 
 mutable struct StreamInfo
     stream_index0::Int             # zero-based
@@ -640,7 +641,7 @@ each frame, and seeking back to the start.
 """
 function counttotalframes(s::VideoReader)
     seekstart(s)
-    n = 1
+    n = 0
     while true
         skipframe(s, throwEOF = false) && break
         n += 1

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -11,7 +11,7 @@ mutable struct VideoEncoder
 end
 
 """
-encode(encoder::VideoEncoder, io::IO)
+    encode(encoder::VideoEncoder, io::IO)
 
 Encode frame in memory
 """
@@ -56,7 +56,7 @@ end
 isfullcolorrange(props) = (findfirst(map(x->x == Pair(:color_range,2),props)) != nothing)
 
 """
-prepareencoder(firstimg;framerate=30,AVCodecContextProperties=[:priv_data => ("crf"=>"22","preset"=>"medium")],codec_name::String="libx264")
+    prepareencoder(firstimg;framerate=30,AVCodecContextProperties=[:priv_data => ("crf"=>"22","preset"=>"medium")],codec_name::String="libx264")
 
 Prepare encoder and return AV objects.
 """
@@ -150,7 +150,7 @@ function prepareencoder(firstimg;framerate=30,AVCodecContextProperties=[:priv_da
 end
 
 """
-appendencode(encoder::VideoEncoder, io::IO, img, index::Integer)
+    appendencode(encoder::VideoEncoder, io::IO, img, index::Integer)
 
 Send image object to ffmpeg encoder and encode
 """
@@ -196,7 +196,7 @@ function appendencode!(encoder::VideoEncoder, io::IO, img, index::Integer)
 end
 
 """
-function finishencode(encoder::VideoEncoder, io::IO)
+    finishencode(encoder::VideoEncoder, io::IO)
 
 End encoding by sending endencode package to ffmpeg, and close objects.
 """
@@ -209,7 +209,7 @@ function finishencode!(encoder::VideoEncoder, io::IO)
 end
 
 """
-mux(srcfilename,destfilename,framerate;silent=false,deletestream=true)
+    mux(srcfilename,destfilename,framerate;silent=false,deletestream=true)
 
 Multiplex stream file into video container. Deletes stream file by default.
 """
@@ -228,10 +228,10 @@ function mux(srcfilename,destfilename,framerate;silent=false,deletestream=true)
 end
 
 """
-encodevideo(filename::String,imgstack::Array;
-    AVCodecContextProperties = AVCodecContextPropertiesDefault,
-    codec_name = "libx264",
-    framerate = 24)
+    encodevideo(filename::String,imgstack::Array;
+        AVCodecContextProperties = AVCodecContextPropertiesDefault,
+        codec_name = "libx264",
+        framerate = 24)
 
 Encode image stack to video file and return filepath.
 

--- a/src/testvideos.jl
+++ b/src/testvideos.jl
@@ -15,6 +15,7 @@ mutable struct VideoFile{compression}
     credit::AbstractString
     source::AbstractString
     download_url::AbstractString
+    numframes::Int
 end
 
 show(io::IO, v::VideoFile) = print(io, """
@@ -25,9 +26,10 @@ show(io::IO, v::VideoFile) = print(io, """
                                      credit:       $(v.credit)
                                      source:       $(v.source)
                                      download_url: $(v.download_url)
+                                     numframes:    $(v.numframes)
                                    """)
 
-VideoFile(name, description, license, credit, source, download_url) = VideoFile{:raw}(name, description, license, credit, source, download_url)
+VideoFile(name, description, license, credit, source, download_url, numframes) = VideoFile{:raw}(name, description, license, credit, source, download_url, numframes)
 
 # Standard test videos
 const videofiles  =  Dict(
@@ -37,6 +39,7 @@ const videofiles  =  Dict(
                                                 "CC-BY NatureClip (http://youtube.com/natureclip)",
                                                 "https://downloadnatureclip.blogspot.com/p/download-links.html",
                                                 "https://archive.org/download/LadybirdOpeningWingsCCBYNatureClip/Ladybird%20opening%20wings%20CC-BY%20NatureClip.mp4",
+                                                396,
                                                 ),
 
                     "annie_oakley.ogg" => VideoFile("annie_oakley.ogg",
@@ -44,7 +47,9 @@ const videofiles  =  Dict(
                                                     "pubic_domain (US)",
                                                     "",
                                                     "https://commons.wikimedia.org/wiki/File:Annie_Oakley_shooting_glass_balls,_1894.ogg",
-                                                    "https://upload.wikimedia.org/wikipedia/commons/8/87/Annie_Oakley_shooting_glass_balls%2C_1894.ogv"),
+                                                    "https://upload.wikimedia.org/wikipedia/commons/8/87/Annie_Oakley_shooting_glass_balls%2C_1894.ogv",
+                                                    726,
+                                                    ),
 
                     "crescent-moon.ogv" => VideoFile("crescent-moon.ogv",
                                                      "Moonset (time-lapse).",
@@ -52,6 +57,7 @@ const videofiles  =  Dict(
                                                      "Photo : Thomas Bresson",
                                                      "https://commons.wikimedia.org/wiki/File:2010-10-10-Lune.ogv",
                                                      "https://upload.wikimedia.org/wikipedia/commons/e/ef/2010-10-10-Lune.ogv",
+                                                     1213,
                                                      ),
 
                     "black_hole.webm" => VideoFile("black_hole.webm",
@@ -60,6 +66,7 @@ const videofiles  =  Dict(
                                                    "Credit: ESO/L. Calçada",
                                                    "https://www.eso.org/public/videos/eso1004a/",
                                                    "https://upload.wikimedia.org/wikipedia/commons/1/13/Artist%E2%80%99s_impression_of_the_black_hole_inside_NGC_300_X-1_%28ESO_1004c%29.webm",
+                                                   597,
                                                    ),
                      )
 

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -86,6 +86,12 @@ end
             else
                 !createmode && (@test img == first_frame)
             end
+            
+            # Skipping & frame counting
+            VideoIO.seekstart(v)
+            VideoIO.skipframe(v)
+            VideoIO.skipframes(v, 10)
+            @test VideoIO.counttotalframes(v) == VideoIO.TestVideos.videofiles[name].numframes
 
             close(v)
         end
@@ -146,10 +152,14 @@ end
 @testset "Encoding video across all supported colortypes" begin
     for el in [UInt8, RGB{N0f8}]
         @testset "Encoding $el imagestack" begin
-            imgstack = map(x->rand(el,100,100),1:100)
+            n = 100
+            imgstack = map(x->rand(el,100,100),1:n)
             props = [:priv_data => ("crf"=>"22","preset"=>"medium")]
             encodedvideopath = VideoIO.encodevideo("testvideo.mp4",imgstack,framerate=30,AVCodecContextProperties=props, silent=true)
             @test stat(encodedvideopath).size > 100
+            f = VideoIO.openvideo(encodedvideopath)
+            @test VideoIO.counttotalframes(f) == n-4 # videos encoded with crf > 0 have 4 fewer frames
+            close(f)
             rm(encodedvideopath)
         end
     end
@@ -227,6 +237,8 @@ end
         frame_test = collect(rawview(channelview(read(f))))
         h_test = fit(Histogram, frame_test[:], 0:256)
         @test h_test.weights == fill(1,256) #Test that encoding is precise (if above passes)
+
+        @test VideoIO.counttotalframes(f) == 24
     end
 
     @testset "Correct frame order when reading & encoding" begin
@@ -239,6 +251,7 @@ end
                 push!(frame_ids_truth,img[1,1])
             end
             @test frame_ids_truth == collect(0:255) #Test that reading is in correct frame order
+            @test VideoIO.counttotalframes(f) == 256
         end
         @testset "Frame order when encoding, then reading video" begin
             # Test that writing and reading a video with frame-incremental pixel values is read in in-order
@@ -258,6 +271,7 @@ end
                 push!(frame_ids_test,img[1,1])
             end
             @test frame_ids_test == collect(0:255) #Test that reading is in correct frame order
+            @test VideoIO.counttotalframes(f) == 256
         end
     end
 end


### PR DESCRIPTION
The objective here is to provide the fastest way to 
1) skip through a frame 
2) skip through multiple frames 
3) get the most accurate & fastest count of remaining available frames

@rdeits @yakir12 What do you think about these?

I'll add tests if they look good