### PR TITLE
Allow encoding with rational frame rates

### DIFF
--- a/src/ffmpeg/AVUtil/src/AVUtil.jl
+++ b/src/ffmpeg/AVUtil/src/AVUtil.jl
@@ -4,6 +4,8 @@ module AVUtil
 
   include(w("LIBAVUTIL.jl"))
 
+AVRational(r::Rational) = AVRational(numerator(r), denominator(r))
+
     #If AVUtil v55 is needed, this will need to be added back
   #Base.zero(::Type{AVRational}) = AVRational(0, 1)
 


### PR DESCRIPTION
While ffmpeg allows the use of rational frame rates, VideoIO.jl assumes that frame rates can only be integers. Many video capture devices do not have exactly integer frame rates, making it difficult to process their output with VideoIO.jl. I have therefore made simple modifications to the encoding code to allow rational frame rates.