### PR TITLE
Increase efficiency of accessing members of struct pointers

### DIFF
--- a/src/ffmpeg/AVUtil/v56/LIBAVUTIL.jl
+++ b/src/ffmpeg/AVUtil/v56/LIBAVUTIL.jl
@@ -54,10 +54,10 @@ function AVFrame()
   ts = AVFrame.types
   parms = [T <: Ptr ? C_NULL : zero(T) for T in ts]
 
-  fmt_pos = fieldposition(AVFrame, :format)
+  fmt_pos = Base.fieldindex(AVFrame, :format)
   parms[fmt_pos] = -one(ts[fmt_pos])
 
-  pts_pos = fieldposition(AVFrame, :pts)
+  pts_pos = Base.fieldindex(AVFrame, :pts)
   parms[pts_pos] = AV_NOPTS_VALUE
 
   AVFrame(parms...)

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,27 +1,18 @@
 # Helpful utility functions
 
-function fieldposition(::Type{T}, name::Symbol) where T
-    field_pos = findfirst(isequal(name), fieldnames(T))
-    if field_pos === nothing
-        throw(ErrorException("The type `$T` does not contain field $name!"))
-    end
-    return field_pos
-end
-
 # Set the value of a field of a pointer
 # Equivalent to s->name = value
 function av_setfield(s::Ptr{T}, name::Symbol, value) where T
-    field_pos = fieldposition(T, name)
+    field_pos = Base.fieldindex(T, name)
     byteoffset = fieldoffset(T, field_pos)
-    S = T.types[field_pos]
+    S = fieldtype(T, name)
 
     p = convert(Ptr{S}, s + byteoffset)
-    a = unsafe_wrap(Array, p, 1)
-    a[1] = convert(S, value)
+    unsafe_store!(p, convert(S, value))
 end
 
 function av_pointer_to_field(s::Ptr{T}, name::Symbol) where T
-    field_pos = fieldposition(T, name)
+    field_pos = Base.fieldindex(T, name)
     byteoffset = fieldoffset(T, field_pos)
     return s + byteoffset
 end


### PR DESCRIPTION
The current code to access a member of a struct pointer uses a package function, `fieldposition`, that has identical functionality to a function provided in base, `fieldindex`. While this latter function is not exported, it is documented and will hopefully remain a part of Julia's API. I imagine that the base function is more performant than the implementation in `fieldposition`, which compares each field name to the target field name in order to find the position of a field. As such, I have replaced calls to `fieldposition` with calls to `Base.fieldindex`, and deleted the function `fieldposition`.

Additionally, when setting a member of a struct pointer, the current implementation calculates the pointer position, wraps it in a julia array with `unsafe_wrap`, and then sets the first element of that array to the desired value. The same result is achieved, perhaps more simply, by using `unsafe_store!` and not using an intermediate array. I have therefore replaced the call to `unsafe_wrap` and subsequent code with `unsafe_store!`.

While I do not know if the existing code causes a measurable decrease in performance, using the base functions reduces the amount of code, and most likely makes it faster.