### PR TITLE
Add optional nvidia hardware-accelerated h264_nvenc encoding

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -1,0 +1,23 @@
+name: Run tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ['1']
+        julia-arch: [x64, x86]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        exclude:
+          - os: macOS-latest
+            julia-arch: x86
+
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/julia-runtest@master
+      

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 ColorTypes = "0.9, 0.10"
-FFMPEG = "0.2, 0.3"
+FFMPEG = "0.2, 0.3, 0.4"
 Glob = "1.2"
 ImageCore = "0.8"
 ImageTransformations = "0.8"

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -74,7 +74,7 @@ function prepareencoder(firstimg;framerate::Union{Rational, Integer}=30,AVCodecC
     apPacket = Ptr{AVPacket}[av_packet_alloc()]
     apPacket == [C_NULL] && error("av_packet_alloc() error")
 
-    if eltype(firstimg) == UInt8 && (codec_name == "libx264")
+    if eltype(firstimg) == UInt8 && (codec_name in ["libx264", "h264_nvenc"])
         if islossless(AVCodecContextProperties)
             if !isfullcolorrange(AVCodecContextProperties)
                 @warn """Encoding output not lossless.
@@ -84,7 +84,7 @@ function prepareencoder(firstimg;framerate::Union{Rational, Integer}=30,AVCodecC
             end
         end
         pix_fmt = AV_PIX_FMT_GRAY8
-    elseif eltype(firstimg) == Gray{N0f8} && (codec_name == "libx264")
+    elseif eltype(firstimg) == Gray{N0f8} && (codec_name in ["libx264", "h264_nvenc"])
         if islossless(AVCodecContextProperties)
             if !isfullcolorrange(AVCodecContextProperties)
                 @warn """Encoding output not lossless.
@@ -103,7 +103,7 @@ function prepareencoder(firstimg;framerate::Union{Rational, Integer}=30,AVCodecC
             will give better playback results"""
         end
         pix_fmt = AV_PIX_FMT_RGB24
-    elseif eltype(firstimg) == RGB{N0f8} && (codec_name == "libx264")
+    elseif eltype(firstimg) == RGB{N0f8} && (codec_name in ["libx264", "h264_nvenc"])
         if islossless(AVCodecContextProperties)
             @warn """Encoding output not lossless.
             libx264 does not support lossless RGB planes. RGB will be downsampled


### PR DESCRIPTION
Hoping to add hardware accelerated encoding, as per https://trac.ffmpeg.org/wiki/HWAccelIntro

Dependent on an updated FFMPEG_jll via https://github.com/JuliaPackaging/Yggdrasil/pull/1384 and https://github.com/JuliaIO/FFMPEG.jl/pull/32

