### PR TITLE
Make accessing members of structs through pointers more efficient

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -2,7 +2,7 @@
 
 # Set the value of a field of a pointer
 # Equivalent to s->name = value
-function av_setfield(s::Ptr{T}, name::Symbol, value) where T
+@inline function av_setfield(s::Ptr{T}, name::Symbol, value) where T
     field_pos = Base.fieldindex(T, name)
     byteoffset = fieldoffset(T, field_pos)
     S = fieldtype(T, name)


### PR DESCRIPTION
As part of #250 I benchmarked the performance of `av_setfield`, and observed that it currently takes ~380 ns. While this is fast, it's not as fast as I would expect for what should boil down to a few machine instructions. This is primarily due to the seemingly inherent type instability of accessing a field by its name. However, upon further reflection, this didn't make sense to me, as this should happen every time you access a field in Julia (e.g. `foo.a` which is translated to `getproperty(foo, sym)`, which is in turn translated to `getfield(foo, sym)` where `sym = :a`). Unlike in the generic case, where you don't know ahead of time which field will be accessed, if the call occurs inside of a function, the field name is a constant which can be utilized by the compiler. I therefore wondered if my benchmarks in #250 were unnecessarily slow, and that calls to `av_setfield` inside of a function would be more performant because the symbol would be constant, and the data type of the field could then in principle be known by compiler. Simple testing of this idea revealed that it was not the case. However, the problematic line of `av_setfield`, `S = fieldtype(T, name)`, could be made type stable in other functions. Why wasn't the compiler using the data type of the field in this case, when it can in other cases?

I realized that it was because `av_setfield` was not being inlined by the compiler, so that the constant field name inside a function could not being utilized to eliminate type instability. By adding the `@inline` compiler hint to `av_setfield`, the compiler now knows what c type the arguments must be cast to before storing it in the c struct, although this is only true if you use `av_setfield` inside of a function. This minimal change successfully eliminates type instability, and simple benchmarking shows that the original 383 ns run time of `av_setfield` is reduced to 34 ns if it is used inside of a function.
