### PR TITLE
Allow encode with float framerates via Rational conversion

### DIFF
--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -60,7 +60,7 @@ isfullcolorrange(props) = (findfirst(map(x->x == Pair(:color_range,2),props)) !=
 
 Prepare encoder and return AV objects.
 """
-function prepareencoder(firstimg;framerate::Union{Rational, Integer}=30,AVCodecContextProperties=[:priv_data => ("crf"=>"22","preset"=>"medium")],codec_name::String="libx264")
+function prepareencoder(firstimg; framerate=30, AVCodecContextProperties=[:priv_data => ("crf"=>"22","preset"=>"medium")], codec_name::String="libx264")
     height = size(firstimg,1)
     width = size(firstimg,2)
     ((width % 2 !=0) || (height % 2 !=0)) && error("Encoding error: Image dims must be a multiple of two")
@@ -209,7 +209,7 @@ function finishencode!(encoder::VideoEncoder, io::IO)
     av_packet_free(encoder.apPacket)
 end
 
-ffmpeg_framerate_string(fr::Integer) = string(fr)
+ffmpeg_framerate_string(fr) = string(fr)
 ffmpeg_framerate_string(fr::Rational) = "$(numerator(fr))/$(denominator(fr))"
 
 """
@@ -217,7 +217,7 @@ ffmpeg_framerate_string(fr::Rational) = "$(numerator(fr))/$(denominator(fr))"
 
 Multiplex stream file into video container. Deletes stream file by default.
 """
-function mux(srcfilename,destfilename,framerate::Union{Integer,Rational};silent=false,deletestream=true)
+function mux(srcfilename, destfilename, framerate; silent=false, deletestream=true)
     fr_str = ffmpeg_framerate_string(framerate)
     muxout = FFMPEG.exe(`-y -framerate $fr_str -i $srcfilename -c copy $destfilename`, collect=true)
     filter!(x->!occursin.("Timestamps are unset in a packet for stream 0.",x),muxout) #known non-bug issue with h264

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -209,8 +209,10 @@ function finishencode!(encoder::VideoEncoder, io::IO)
     av_packet_free(encoder.apPacket)
 end
 
-ffmpeg_framerate_string(fr) = string(fr)
+ffmpeg_framerate_string(fr::Real) = string(fr)
+ffmpeg_framerate_string(fr::String) = fr
 ffmpeg_framerate_string(fr::Rational) = "$(numerator(fr))/$(denominator(fr))"
+ffmpeg_framerate_string(fr) = error("Framerate type not valid. Mux framerate should be a subtype of Real (Integer, Float64, Rational etc.), or String")
 
 """
     mux(srcfilename,destfilename,framerate;silent=false,deletestream=true)

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -203,6 +203,23 @@ end
         rm(encodedvideopath)
     end
 end
+@testset "Encoding video with float frame rates" begin
+    n = 100
+    fr = 29.5 # 59 // 2
+    target_dur = 3.39
+    @testset "Encoding with frame rate $(float(fr))" begin
+        imgstack = map(x->rand(UInt8,100,100),1:n)
+        props = [:priv_data => ("crf"=>"22","preset"=>"medium")]
+        encodedvideopath = VideoIO.encodevideo("testvideo.mp4",imgstack,
+                                               framerate=fr,
+                                               AVCodecContextProperties=props,
+                                               silent=true)
+        @test stat(encodedvideopath).size > 100
+        measured_dur_str = VideoIO.FFMPEG.exe(`-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 $(encodedvideopath)`, command = VideoIO.FFMPEG.ffprobe, collect = true)
+        @test parse(Float64, measured_dur_str[1]) == target_dur
+        rm(encodedvideopath)
+    end
+end
 
 @testset "Video encode/decode accuracy (read, encode, read, compare)" begin
     file = joinpath(videodir, "annie_oakley.ogg")


### PR DESCRIPTION
In #249 the framerate arg in `prepareencoder` and `mux` was restricted to `Integer` or `Rational`, however floats can also be passed as the conversion into `Rational` will handle them.

That PR also introduced a breaking change that I missed as the type of the kwargs became more limited, and it was actually possible to pass floats, as long as they rounded to `Integer` successfully.

cc @galenlynch 

