### PR TITLE
Fix one instance of type instability within VideoReader

### DIFF
--- a/src/avio.jl
+++ b/src/avio.jl
@@ -266,7 +266,7 @@ function VideoReader(avin::AVInput, video_stream=1;
 
     aspect_num = codecContext.sample_aspect_ratio.num
     aspect_den = codecContext.sample_aspect_ratio.den
-    aspect_ratio = (aspect_den == 0) ? 0 // 1 : aspect_num // aspect_den
+    aspect_ratio = (aspect_den == 0) ? Cint(0) // Cint(1) : aspect_num // aspect_den
 
     # Find the decoder for the video stream
     pVideoCodec = avcodec_find_decoder(codecContext.codec_id)


### PR DESCRIPTION
In `VideoReader`'s constructor, `aspect_ratio` is either set to the aspect ratio from the codec context, which is converted into a `Rational{Cint}`, or instead `0 // 1` if the denominator is zero, which is a `Rational{Int}`. This causes unceccessary type instability, which can be fixed by instead making `aspect_ratio = Cint(0) // Cint(1)` if the denominator is zero.