### PR TITLE
Make some fields in `VideoReader` concrete types

### DIFF
--- a/src/avio.jl
+++ b/src/avio.jl
@@ -84,8 +84,8 @@ mutable struct VideoReader{transcode} <: StreamContext
     format::Cint
     width::Cint
     height::Cint
-    framerate::Rational
-    aspect_ratio::Rational
+    framerate::Rational{Cint}
+    aspect_ratio::Rational{Cint}
 
     frame_queue::Vector{Vector{UInt8}}
     transcodeContext::VideoTranscodeContext


### PR DESCRIPTION
Two fields of `VideoReader`, `framerate` and `aspect_ratio`, are both of type `Rational`, an abstract type. In reality, the constructor of `VideoReader` sets both of these fields to be type `Rational{Cint}`. By changing the type definition to reflect that, it reduces type instability in code accessing `VideoReader` fields, while not restricting the generality of `VideoReader`.