### PR TITLE
Assert return type of `eof`

### DIFF
--- a/src/avio.jl
+++ b/src/avio.jl
@@ -686,7 +686,7 @@ end
 function eof(avin::AVInput{I}) where I <: IO
     !isopen(avin) && return true
     have_frame(avin) && return false
-    return eof(avin.io)
+    return eof(avin.io)::Bool
 end
 
 eof(r::VideoReader) = eof(r.avin)


### PR DESCRIPTION
Currently, the Julia compiler cannot infer the return type of `eof`. I am not
100% sure why it exhibits type instability, but we can at least assert that the
return type will be a `Bool`, and limit the spread of that type instability.

This type assertion will hopefully be removed at some point when the code is
made type stable.