### PR TITLE
Add utility function `get_number_frames`

### DIFF
--- a/docs/src/reading.md
+++ b/docs/src/reading.md
@@ -147,3 +147,6 @@ VideoIO.get_time_duration
 ```@docs
 VideoIO.get_duration
 ```
+```@docs
+VideoIO.get_number_frames
+```

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -166,6 +166,14 @@ end
         @test VideoIO.get_duration(file) == 24224200/1e6
         @test VideoIO.get_start_time(file) == DateTime(1970, 1, 1)
         @test VideoIO.get_time_duration(file) == (DateTime(1970, 1, 1), 24224200/1e6)
+        @test VideoIO.get_number_frames(file) === nothing
+    end
+    @testset "Reading the number of frames from container" begin
+        file = joinpath(videodir, "ladybird.mp4")
+        @test VideoIO.get_number_frames(file) == 398
+        @test VideoIO.get_number_frames(file, 0) == 398
+        @test_throws ArgumentError VideoIO.get_number_frames(file, -1)
+        @test_throws ErrorException VideoIO.get_number_frames("Not_a_file")
     end
 end
 


### PR DESCRIPTION
There is currently no way to query a video container to determine the number of video frames that it contains, besides decoding the video and counting the frames. While this is the best you can do for some container formats, other container formats can report the number of frames without decoding each video frame. I have added a new function, `get_number_frames`, which will query the container and return the number of frames, if applicable, or return `nothing` otherwise. This function will not decode the video stream in order to determine the number of frames.

I have additionally added simple tests of this function, a documentation string, and added it to the docs.