### PR TITLE
Add iterator interface to VideoReader objects

### DIFF
--- a/docs/src/reading.md
+++ b/docs/src/reading.md
@@ -9,10 +9,12 @@ video frames from a supported video file (or from a camera device, shown later).
 ```julia
 using VideoIO
 
-#io = VideoIO.open(video_file)
+# Construct a AVInput object to access the video and audio streams in a video container
+# io = VideoIO.open(video_file)
 io = VideoIO.testvideo("annie_oakley") # for testing purposes
 
-f = VideoIO.openvideo(io)
+# Access the video stream in an AVInput, and return a VideoReader object:
+f = VideoIO.openvideo(io) # you can also use a file name, instead of a AVInput
 
 img = read(f)
 
@@ -22,6 +24,37 @@ while !eof(f)
 end
 close(f)
 ```
+
+Alternatively, you can open the video stream in a file directly with
+`VideoIO.openvideo(filename)`, without making an intermediate `AVInput`
+object, if you only need the video.
+
+VideoIO also provides an iterator interface for [`VideoReader`](@ref), which
+behaves like other mutable iterators in Julia (e.g. Channels). If iteration is
+stopped early, for example with a `break` statement, then it can be resumed in
+the same spot by iterating on the same `VideoReader` object. Consequently, if
+you have already iterated over all the frames of a `VideoReader` object, then it
+will be empty for further iteration unless its position in the video is changed
+with `seek`.
+
+```julia
+using VideoIO
+
+
+io = VideoIO.testvideo("annie_oakley")
+f = VideoIO.openvideo(io)
+
+for img in f
+    # Do something with img
+end
+
+# You can also use collect(f) to get all of the frames
+
+# Further iteration will show that f is now empty!
+
+close(f)
+```
+
 
 Seeking through the video can be achieved via `seek(f, seconds::Float64)` and `seekstart(f)` to return to the start.
 ```@docs

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -6,6 +6,8 @@ using ImageCore: permuteddimsview, channelview, rawview #0.723065 seconds
 using ColorTypes: RGB, Gray, N0f8, YCbCr                #0.529263 seconds
 using ImageTransformations: restrict                    #3.156594 seconds!!
 
+import Base: iterate, IteratorSize, IteratorEltype
+
 include("init.jl")
 include("util.jl")
 include(joinpath(av_load_path, "AVUtil", "src", "AVUtil.jl"))

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -93,6 +93,15 @@ end
 
 show(io::IO, vr::VideoReader) = print(io, "VideoReader(...)")
 
+function iterate(r::VideoReader, state = 0)
+    eof(r) && return
+    return read(r), state + 1
+end
+
+IteratorSize(::Type{<:VideoReader}) = Base.SizeUnknown()
+
+IteratorEltype(::Type{<:VideoReader}) = Base.EltypeUnknown()
+
 # Pump input for data
 function pump(c::AVInput)
     pFormatContext = c.apFormatContext[1]

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -162,11 +162,7 @@ end
 
             ## Test that iterator is mutable, and continues where iteration last
             ## stopped.
-            i = 0
-            for _ in v
-                i += 1
-            end
-            @test i == 0
+            @test iterate(v) === nothing
         end
     end
 

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -155,10 +155,20 @@ end
 
             VideoIO.seekstart(v)
             i = 0
-            for _ in v
+            local first_frame
+            local last_frame
+            for frame in v
                 i += 1
+                if i == 1
+                    first_frame = frame
+                end
+                last_frame = frame
             end
             @test i == VideoIO.TestVideos.videofiles[name].numframes
+            # test that the frames returned by the iterator have distinct storage
+            if i > 1
+                @test first_frame !== last_frame
+            end
 
             ## Test that iterator is mutable, and continues where iteration last
             ## stopped.

--- a/test/avio.jl
+++ b/test/avio.jl
@@ -123,12 +123,11 @@ end
     for name in VideoIO.TestVideos.names()
         # TODO: fix me?
         (startswith(name, "ladybird") || startswith(name, "NPS")) && continue
-
-        first_frame_file = joinpath(testdir, swapext(name, ".png"))
-        first_frame = load(first_frame_file)
-        filename = joinpath(videodir, name)
-
         @testset "Testing $name" begin
+            first_frame_file = joinpath(testdir, swapext(name, ".png"))
+            first_frame = load(first_frame_file)
+
+            filename = joinpath(videodir, name)
             v = VideoIO.openvideo(VideoIO.open(filename))
 
             if size(first_frame, 1) > v.height
@@ -155,8 +154,19 @@ end
             @test Base.IteratorEltype(VT) === Base.EltypeUnknown()
 
             VideoIO.seekstart(v)
-            @test length(collect(v)) == VideoIO.TestVideos.videofiles[name].numframes
-            @test length(collect(v)) == 0
+            i = 0
+            for _ in v
+                i += 1
+            end
+            @test i == VideoIO.TestVideos.videofiles[name].numframes
+
+            ## Test that iterator is mutable, and continues where iteration last
+            ## stopped.
+            i = 0
+            for _ in v
+                i += 1
+            end
+            @test i == 0
         end
     end
 


### PR DESCRIPTION
I have added an iterator interface to the `VideoReader` type, making collecting all frames of a video as simple as:

```julia
f = openvideo(fname)
imgs = collect(f)
```

The iterator returns a new array for each frame, as I think mutating the same array on subsequent calls to `iterate` would be surprising and lead to strange behavior when calling functions such as `collect`. Note that the VideoReader iterator is mutable, like Channel or Stateful iterators in Julia, and will resume iteration where it was last stopped, instead of at the beginning. I have added some text in the documentation explaining this behavior, and also added some tests.