### PR TITLE
Remove `permuteddimsview`, which is deprecated

### DIFF
--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -1,10 +1,10 @@
 module VideoIO
 
-using Libdl                                             #0.227492 seconds
-using Requires, Dates, ProgressMeter                    #0.001749 seconds
-using ImageCore: channelview, rawview #0.723065 seconds
-using ColorTypes: RGB, Gray, N0f8, YCbCr                #0.529263 seconds
-using ImageTransformations: restrict                    #3.156594 seconds!!
+using Libdl
+using Requires, Dates, ProgressMeter
+using ImageCore: channelview, rawview
+using ColorTypes: RGB, Gray, N0f8, YCbCr
+using ImageTransformations: restrict
 
 import Base: iterate, IteratorSize, IteratorEltype
 

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -2,7 +2,7 @@ module VideoIO
 
 using Libdl                                             #0.227492 seconds
 using Requires, Dates, ProgressMeter                    #0.001749 seconds
-using ImageCore: permuteddimsview, channelview, rawview #0.723065 seconds
+using ImageCore: channelview, rawview #0.723065 seconds
 using ColorTypes: RGB, Gray, N0f8, YCbCr                #0.529263 seconds
 using ImageTransformations: restrict                    #3.156594 seconds!!
 

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -388,9 +388,9 @@ function retrieve(r::VideoReader{TRANSCODE}) # true=transcode
     end
 
     if t.target_bits_per_pixel == 8
-        buf = permuteddimsview(Matrix{Gray{N0f8}}(undef, r.width, r.height), (2, 1))
+        buf = PermutedDimsArray(Matrix{Gray{N0f8}}(undef, r.width, r.height), (2, 1))
     else
-        buf = permuteddimsview(Matrix{RGB{N0f8}}(undef, r.width, r.height), (2, 1))
+        buf = PermutedDimsArray(Matrix{RGB{N0f8}}(undef, r.width, r.height), (2, 1))
     end
 
     retrieve!(r, buf)


### PR DESCRIPTION
`permuteddimsview` has been deprecated in ImageCore.jl, in favor of `PermutedDimsArray` in Base. I have replaced `permuteddimsview` with `PermutedDimsArray` in this package to avoid deprecation warnings.