### PR TITLE
Add code for non-transcoded video streams

### DIFF
--- a/src/avio.jl
+++ b/src/avio.jl
@@ -405,7 +405,7 @@ function retrieve(r::VideoReader{NO_TRANSCODE}) # false=don't transcode
 
     # TODO: set actual dimensions ?
     buf_sz = avpicture_get_size(r.format, r.width, r.height)
-    buf = Array(UInt8, buf_sz)
+    buf = Array{UInt8}(undef, buf_sz)
 
     retrieve!(r, buf)
 end
@@ -476,6 +476,10 @@ function retrieve!(r::VideoReader{NO_TRANSCODE}, buf::VidArray{T}) where T <: Ei
     if !bufsize_check(r, buf)
         error("Buffer is the wrong size")
     end
+
+    unsafe_copyto!(pointer(buf), r.aVideoFrame[1].data[1], sizeof(buf))
+
+    return buf
 end
 
 # Utility functions

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -479,6 +479,8 @@ function retrieve!(r::VideoReader{NO_TRANSCODE}, buf::VidArray{T}) where T <: Ei
 
     unsafe_copyto!(pointer(buf), r.aVideoFrame[1].data[1], sizeof(buf))
 
+    reset_frame_flag!(r)
+
     return buf
 end
 


### PR DESCRIPTION
Fixes #111 and enables frames to be grabbed from a webcam without transcoding. This is particularly useful when only luminance values are required and the transcoding to RGB is actually unhelpful. 

I use this within a Raspberry Pi computer vision system for control. As such, speed is important - without transcoding I can grab a frame in 1.5ms whereas with transcoding it takes 63.5ms.

The data is returned in a UInt8 array rather than a more specifically typed array but this seems to be in line with the original (unimplemented) intent. To interpret this data, the specific webcam pixel format needs to be known but that is relatively trivial (see `cam = VideoIO.opencamera(;transcode=false); cam.format` and compare against the `AVPixelFormat` values in `libavutil_h.jl`.