### PR TITLE
Disable fail fast github actions CI

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         julia-version: ['1']
         julia-arch: [x64, x86]


### PR DESCRIPTION
@galenlynch I thought this might make your testing more manageable