### PR TITLE
Naming and settings fixes

### DIFF
--- a/docs/src/writing.md
+++ b/docs/src/writing.md
@@ -9,8 +9,8 @@ Videos can be encoded directly from image stack using `VideoIO.save(filename::St
 The entire image stack can be encoded in a single step:
 ```julia
 import VideoIO
-encoder_settings = (crf=23, preset="medium")
-VideoIO.save("video.mp4", imgstack, framerate=30, encoder_settings=encoder_settings)
+encoder_options = (crf=23, preset="medium")
+VideoIO.save("video.mp4", imgstack, framerate=30, encoder_options=encoder_options)
 ```
 
 ```@docs
@@ -25,9 +25,9 @@ Alternatively, videos can be encoded iteratively within custom loops.
 using VideoIO
 framestack = map(x->rand(UInt8, 100, 100), 1:100) #vector of 2D arrays
 
-encoder_settings = (crf=23, preset="medium")
+encoder_options = (crf=23, preset="medium")
 framerate=24
-open_video_out("video.mp4", framestack[1], framerate=framerate, encoder_settings=encoder_settings) do writer
+open_video_out("video.mp4", framestack[1], framerate=framerate, encoder_options=encoder_options) do writer
     for i in eachindex(framestack)
         append_encode_mux!(writer, framestack[i], i)
     end
@@ -45,10 +45,10 @@ intstrings =  map(x->split(x,".")[1], imgnames) # Extract index from filenames
 p = sortperm(parse.(Int, intstrings)) #sort files numerically
 imgnames = imgnames[p]
 
-encoder_settings = (crf=23, preset="medium")
+encoder_options = (crf=23, preset="medium")
 
 firstimg = load(joinpath(dir, imgnames[1]))
-open_video_out("video.mp4", firstimg, framerate=24, encoder_settings=encoder_settings) do writer
+open_video_out("video.mp4", firstimg, framerate=24, encoder_options=encoder_options) do writer
     @showprogress "Encoding video frames.." for i in eachindex(imgnames)
         img = load(joinpath(dir, imgnames[i]))
         append_encode_mux!(writer, img, i)
@@ -81,7 +81,7 @@ Optional fields can be found [here](https://ffmpeg.org/doxygen/4.1/structAVCodec
 
 A few helpful presets for h264:
 
-| Goal | `encoder_settings` value |
+| Goal | `encoder_options` value |
 |:----:|:------|
 | Perceptual compression, h264 default. Best for most cases | ```(crf=23, preset="medium")``` |
 | Lossless compression. Fastest, largest file size | ```(crf=0, preset="ultrafast")``` |

--- a/docs/src/writing.md
+++ b/docs/src/writing.md
@@ -81,20 +81,20 @@ Optional fields can be found [here](https://ffmpeg.org/doxygen/4.1/structAVCodec
 
 A few helpful presets for h264:
 
-| Goal | `AVCodecContextProperties` value |
+| Goal | `encoder_settings` value |
 |:----:|:------|
-| Perceptual compression, h264 default. Best for most cases | ```(priv_data = (crf=23, preset="medium"))``` |
-| Lossless compression. Fastest, largest file size | ```(priv_data = (crf=0, preset="ultrafast"))``` |
-| Lossless compression. Slowest, smallest file size | ```(priv_data = (crf=0, preset="ultraslow"))``` |
+| Perceptual compression, h264 default. Best for most cases | ```(crf=23, preset="medium")``` |
+| Lossless compression. Fastest, largest file size | ```(crf=0, preset="ultrafast")``` |
+| Lossless compression. Slowest, smallest file size | ```(crf=0, preset="ultraslow")``` |
 | Direct control of bitrate and frequency of intra frames (every 10) | ```[:bit_rate => 400000,:gop_size = 10,:max_b_frames=1]``` |
 
 ## Lossless Encoding
 ### Lossless RGB
-If lossless encoding of `RGB{N0f8}` is required, _true_ lossless requires using `codec_name = "libx264rgb"`, to avoid the lossy RGB->YUV420 conversion, and `"crf" => "0"`.
+If lossless encoding of `RGB{N0f8}` is required, _true_ lossless requires using `codec_name = "libx264rgb"`, to avoid the lossy RGB->YUV420 conversion, and `crf=0`.
 
 ### Lossless Grayscale
-If lossless encoding of `Gray{N0f8}` or `UInt8` is required, `"crf" => "0"` should be set, as well as `:color_range=>2` to ensure full 8-bit pixel color representation. i.e.
-```[:color_range=>2, :priv_data => ("crf"=>"0","preset"=>"medium")]```
+If lossless encoding of `Gray{N0f8}` or `UInt8` is required, `crf=0` should be set, as well as `color_range=2` to ensure full 8-bit pixel color representation. i.e.
+```(color_range=2, crf=0, preset="medium")```
 
 ### Encoding Performance
 See [`examples/lossless_video_encoding_testing.jl`](https://github.com/JuliaIO/VideoIO.jl/blob/master/examples/lossless_video_encoding_testing.jl) for testing of losslessness, speed, and compression as a function of h264 encoding preset, for 3 example videos.

--- a/docs/src/writing.md
+++ b/docs/src/writing.md
@@ -9,7 +9,7 @@ Videos can be encoded directly from image stack using `VideoIO.save(filename::St
 The entire image stack can be encoded in a single step:
 ```julia
 import VideoIO
-encoder_settings = (crf="22", preset="medium")
+encoder_settings = (crf=23, preset="medium")
 VideoIO.save("video.mp4", imgstack, framerate=30, encoder_settings=encoder_settings)
 ```
 
@@ -25,7 +25,7 @@ Alternatively, videos can be encoded iteratively within custom loops.
 using VideoIO
 framestack = map(x->rand(UInt8, 100, 100), 1:100) #vector of 2D arrays
 
-encoder_settings = (crf="22", preset="medium")
+encoder_settings = (crf=23, preset="medium")
 framerate=24
 open_video_out("video.mp4", framestack[1], framerate=framerate, encoder_settings=encoder_settings) do writer
     for i in eachindex(framestack)
@@ -45,7 +45,7 @@ intstrings =  map(x->split(x,".")[1], imgnames) # Extract index from filenames
 p = sortperm(parse.(Int, intstrings)) #sort files numerically
 imgnames = imgnames[p]
 
-encoder_settings = (crf="22", preset="medium")
+encoder_settings = (crf=23, preset="medium")
 
 firstimg = load(joinpath(dir, imgnames[1]))
 open_video_out("video.mp4", firstimg, framerate=24, encoder_settings=encoder_settings) do writer
@@ -83,9 +83,9 @@ A few helpful presets for h264:
 
 | Goal | `AVCodecContextProperties` value |
 |:----:|:------|
-| Perceptual compression, h264 default. Best for most cases | ```(priv_data = (crf="23", preset="medium"))``` |
-| Lossless compression. Fastest, largest file size | ```(priv_data = (crf="0", preset="ultrafast"))``` |
-| Lossless compression. Slowest, smallest file size | ```(priv_data = (crf="0", preset="ultraslow"))``` |
+| Perceptual compression, h264 default. Best for most cases | ```(priv_data = (crf=23, preset="medium"))``` |
+| Lossless compression. Fastest, largest file size | ```(priv_data = (crf=0, preset="ultrafast"))``` |
+| Lossless compression. Slowest, smallest file size | ```(priv_data = (crf=0, preset="ultraslow"))``` |
 | Direct control of bitrate and frequency of intra frames (every 10) | ```[:bit_rate => 400000,:gop_size = 10,:max_b_frames=1]``` |
 
 ## Lossless Encoding

--- a/docs/src/writing.md
+++ b/docs/src/writing.md
@@ -4,17 +4,17 @@ Note: Writing of audio streams is not yet implemented
 
 ## Single-step Encoding
 
-Videos can be encoded directly from image stack using `encode_mux_video(filename::String, imgstack::Array)` where `imgstack` is an array of image arrays with identical type and size.
+Videos can be encoded directly from image stack using `VideoIO.save(filename::String, imgstack::Array)` where `imgstack` is an array of image arrays with identical type and size.
 
 The entire image stack can be encoded in a single step:
 ```julia
-using VideoIO
+import VideoIO
 encoder_settings = (crf="22", preset="medium")
-encode_mux_video("video.mp4", imgstack, framerate=30, encoder_settings=encoder_settings)
+VideoIO.save("video.mp4", imgstack, framerate=30, encoder_settings=encoder_settings)
 ```
 
 ```@docs
-VideoIO.encode_mux_video
+VideoIO.save
 ```
 
 ## Iterative Encoding
@@ -54,10 +54,6 @@ open_video_out("video.mp4", firstimg, framerate=24, encoder_settings=encoder_set
         append_encode_mux!(writer, img, i)
     end
 end
-```
-
-```@doc
-VideoIO.encode_mux_video
 ```
 
 ```@docs

--- a/docs/src/writing.md
+++ b/docs/src/writing.md
@@ -74,19 +74,22 @@ Encoding of the following image element color types currently supported:
 - `Gray{N0f8}`
 - `RGB{N0f8}`
 
-## Encoder Settings
+## Encoder Options
 
-The `AVCodecContextProperties` object allows control of the majority of settings required.
-Optional fields can be found [here](https://ffmpeg.org/doxygen/4.1/structAVCodecContext.html).
+The `encoder_options` keyword argument allows control over FFmpeg encoding
+options. Optional fields can be found
+[here](https://ffmpeg.org/ffmpeg-codecs.html#Codec-Options).
 
-A few helpful presets for h264:
+More details about options specific to h264 can be found [here](https://trac.ffmpeg.org/wiki/Encode/H.264).
+
+Some example values for the `encoder_options` keyword argument are:
 
 | Goal | `encoder_options` value |
 |:----:|:------|
 | Perceptual compression, h264 default. Best for most cases | ```(crf=23, preset="medium")``` |
 | Lossless compression. Fastest, largest file size | ```(crf=0, preset="ultrafast")``` |
 | Lossless compression. Slowest, smallest file size | ```(crf=0, preset="ultraslow")``` |
-| Direct control of bitrate and frequency of intra frames (every 10) | ```[:bit_rate => 400000,:gop_size = 10,:max_b_frames=1]``` |
+| Direct control of bitrate and frequency of intra frames (every 10) | ```(bit_rate = 400000, gop_size = 10, max_b_frames = 1)``` |
 
 ## Lossless Encoding
 ### Lossless RGB

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -194,8 +194,8 @@ An example of encoding one frame at a time:
 ```julia
 using VideoIO
 framestack = map(x->rand(UInt8, 100, 100), 1:100) #vector of 2D arrays
-encoder_settings = (crf=23, preset="medium")
-open_video_out("video.mp4", framestack[1], framerate=24, encoder_settings=encoder_settings) do writer
+encoder_options = (crf=23, preset="medium")
+open_video_out("video.mp4", framestack[1], framerate=24, encoder_options=encoder_options) do writer
     for i in eachindex(framestack)
         append_encode_mux!(writer, framestack[i], i)
     end

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -194,7 +194,7 @@ An example of encoding one frame at a time:
 ```julia
 using VideoIO
 framestack = map(x->rand(UInt8, 100, 100), 1:100) #vector of 2D arrays
-encoder_settings = (crf="22", preset="medium")
+encoder_settings = (crf=23, preset="medium")
 open_video_out("video.mp4", framestack[1], framerate=24, encoder_settings=encoder_settings) do writer
     for i in eachindex(framestack)
         append_encode_mux!(writer, framestack[i], i)

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -174,7 +174,7 @@ VideoIO supports reading and writing video files.
 - `openvideo` and `opencamera` provide access to video files and livestreams
 - `read` and `read!` allow reading frames
 - `seek`, `seekstart`, `skipframe`, and `skipframes` support access of specific frames
-- `encode_mux_video` for encoding an entire framestack in one step
+- `VideoIO.save` for encoding an entire framestack in one step
 - `open_video_out`, `append_encode_mux!` for writing frames sequentially to a file
 - `gettime` and `counttotalframes` provide information
 

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -236,7 +236,7 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
                      target_colorspace_details = nothing,
                      allow_vio_gray_transform = true,
                      swscale_options::OptionsT = (;),
-                     sws_color_details::OptionsT = (;)) where I
+                     sws_color_options::OptionsT = (;)) where I
     bad_px_type = transcode && target_format !== nothing &&
         !is_pixel_type_supported(target_format)
     bad_px_type && error("Unsupported pixel format $target_format")
@@ -306,7 +306,7 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
                                    codec_context.color_range, dst_pix_fmt,
                                    colorspace_details.color_primaries,
                                    colorspace_details.color_range,
-                                   sws_color_details, swscale_options)
+                                   sws_color_options, swscale_options)
         set_basic_frame_properties!(frame_graph.dstframe, width, height,
                                     dst_pix_fmt)
     end
@@ -569,7 +569,7 @@ arguments listed below.
     settings for the swscale object used to perform color space scaling. Options
     must correspond with options for FFmpeg's
     [scaler](https://ffmpeg.org/ffmpeg-all.html#Scaler-Options) filter.
-- `sws_color_details::OptionsT = (;)`: Additional keyword arguments passed to
+- `sws_color_options::OptionsT = (;)`: Additional keyword arguments passed to
     [sws_setColorspaceDetails]
     (http://ffmpeg.org/doxygen/2.5/group__libsws.html#ga541bdffa8149f5f9203664f955faa040).
 """

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -235,8 +235,8 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
                      pix_fmt_loss_flags = 0,
                      target_colorspace_details = nothing,
                      allow_vio_gray_transform = true,
-                     swscale_settings::SettingsT = (;),
-                     sws_color_details::SettingsT = (;)) where I
+                     swscale_settings::OptionsT = (;),
+                     sws_color_details::OptionsT = (;)) where I
     bad_px_type = transcode && target_format !== nothing &&
         !is_pixel_type_supported(target_format)
     bad_px_type && error("Unsupported pixel format $target_format")
@@ -565,11 +565,11 @@ arguments listed below.
 - `allow_vio_gray_transform = true`: Instead of using `sws_scale` for gray data,
     use a more accurate color space transformation implemented in `VideoIO` if
     `allow_vio_gray_gransform = true`. Otherwise, use `sws_scale`.
-- `swscale_settings::SettingsT = (;)`: A `Namedtuple`, or `Dict{Symbol, Any}` of
+- `swscale_settings::OptionsT = (;)`: A `Namedtuple`, or `Dict{Symbol, Any}` of
     settings for the swscale object used to perform color space scaling. Options
     must correspond with options for FFmpeg's
     [scaler](https://ffmpeg.org/ffmpeg-all.html#Scaler-Options) filter.
-- `sws_color_details::SettingsT = (;)`: Additional keyword arguments passed to
+- `sws_color_details::OptionsT = (;)`: Additional keyword arguments passed to
     [sws_setColorspaceDetails]
     (http://ffmpeg.org/doxygen/2.5/group__libsws.html#ga541bdffa8149f5f9203664f955faa040).
 """

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -235,7 +235,7 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
                      pix_fmt_loss_flags = 0,
                      target_colorspace_details = nothing,
                      allow_vio_gray_transform = true,
-                     swscale_settings::OptionsT = (;),
+                     swscale_options::OptionsT = (;),
                      sws_color_details::OptionsT = (;)) where I
     bad_px_type = transcode && target_format !== nothing &&
         !is_pixel_type_supported(target_format)
@@ -306,7 +306,7 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
                                    codec_context.color_range, dst_pix_fmt,
                                    colorspace_details.color_primaries,
                                    colorspace_details.color_range,
-                                   sws_color_details, swscale_settings)
+                                   sws_color_details, swscale_options)
         set_basic_frame_properties!(frame_graph.dstframe, width, height,
                                     dst_pix_fmt)
     end
@@ -565,7 +565,7 @@ arguments listed below.
 - `allow_vio_gray_transform = true`: Instead of using `sws_scale` for gray data,
     use a more accurate color space transformation implemented in `VideoIO` if
     `allow_vio_gray_gransform = true`. Otherwise, use `sws_scale`.
-- `swscale_settings::OptionsT = (;)`: A `Namedtuple`, or `Dict{Symbol, Any}` of
+- `swscale_options::OptionsT = (;)`: A `Namedtuple`, or `Dict{Symbol, Any}` of
     settings for the swscale object used to perform color space scaling. Options
     must correspond with options for FFmpeg's
     [scaler](https://ffmpeg.org/ffmpeg-all.html#Scaler-Options) filter.

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -530,7 +530,7 @@ If called with a single argument function as the first argument, the `reader`
 will be passed to the function, and will be closed once the call returns whether
 or not an error occurred.
 
-The decoder settings and conversion to Julia arrays is controlled by the keyword
+The decoder options and conversion to Julia arrays is controlled by the keyword
 arguments listed below.
 
 # Keyword arguments
@@ -566,7 +566,7 @@ arguments listed below.
     use a more accurate color space transformation implemented in `VideoIO` if
     `allow_vio_gray_gransform = true`. Otherwise, use `sws_scale`.
 - `swscale_options::OptionsT = (;)`: A `Namedtuple`, or `Dict{Symbol, Any}` of
-    settings for the swscale object used to perform color space scaling. Options
+    options for the swscale object used to perform color space scaling. Options
     must correspond with options for FFmpeg's
     [scaler](https://ffmpeg.org/ffmpeg-all.html#Scaler-Options) filter.
 - `sws_color_options::OptionsT = (;)`: Additional keyword arguments passed to

--- a/src/avptr.jl
+++ b/src/avptr.jl
@@ -192,8 +192,8 @@ end
     ret < 0 && error("Could not set class option $key to $val: got error $ret")
 end
 
-function set_class_options(ptr, settings::OptionsT, args...)
-    for (key, val) in pairs(settings)
+function set_class_options(ptr, options::OptionsT, args...)
+    for (key, val) in pairs(options)
         set_class_option(ptr, key, val, args...)
     end
 end

--- a/src/avptr.jl
+++ b/src/avptr.jl
@@ -1,5 +1,5 @@
 # Utilities for working with pointers to nested C structs
-const SettingsT = Union{AbstractDict{Symbol, <:Any},
+const OptionsT = Union{AbstractDict{Symbol, <:Any},
                         AbstractDict{Union{}, Union{}},
                         NamedTuple}
 
@@ -192,7 +192,7 @@ end
     ret < 0 && error("Could not set class option $key to $val: got error $ret")
 end
 
-function set_class_options(ptr, settings::SettingsT, args...)
+function set_class_options(ptr, settings::OptionsT, args...)
     for (key, val) in pairs(settings)
         set_class_option(ptr, key, val, args...)
     end

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -246,8 +246,8 @@ function VideoWriter(filename::AbstractString, ::Type{T},
 
     if haskey(encoder_options, :priv_data)
         throw(ArgumentError("""The field `priv_data` is no longer supported. Either reorganize as a flat NamedTuple or Dict,
-        i.e. encoder_options=(color_range=2, crf=\"0\", preset=\"medium\") to rely on auto routing of public and private
-        settings, or pass the private settings to `encoder_private_options` explicitly"""))
+        e.g. `encoder_options=(color_range=2, crf=0, preset=\"medium\")` to rely on auto routing of generic and private
+        options, or pass the private options to `encoder_private_options` explicitly"""))
     end
     if !is_eltype_transfer_supported(T)
         throw(ArgumentError("Encoding arrays with eltype $T not yet supported"))
@@ -310,7 +310,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
     if check_ptr_valid(format_context.oformat.priv_class, false)
         set_class_options(format_context.priv_data, container_private_options)
     elseif !isempty(container_private_options)
-        @warn "This container format does not support private settings, and will be ignored"
+        @warn "This container format does not support private options, and will be ignored"
     end
     set_class_options(codec_context, encoder_options)
     set_class_options(codec_context.priv_data, encoder_private_options)
@@ -411,21 +411,21 @@ occurred.
     matrix where frame width is in the first dimension, and frame height is in
     the second.
 - `container_options::OptionsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}`
-    of settings for the container. Must correspond to option names and values
+    of options for the container. Must correspond to option names and values
     accepted by [FFmpeg](https://ffmpeg.org/).
 - `container_private_options::OptionsT = (;)`: A `NamedTuple` or
-    `Dict{Symbol, Any}` of private settings for the container. Must correspond
+    `Dict{Symbol, Any}` of private options for the container. Must correspond
     to private options names and values accepted by
     [FFmpeg](https://ffmpeg.org/) for the chosen container type.
 - `encoder_options::OptionsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}` of
-    settings for the encoder context. Must correspond to option names and values
+    options for the encoder context. Must correspond to option names and values
     accepted by [FFmpeg](https://ffmpeg.org/).
 - `encoder_private_options::OptionsT = (;)`: A `NamedTuple` or
-    `Dict{Symbol, Any}` of private settings for the encoder context. Must
+    `Dict{Symbol, Any}` of private options for the encoder context. Must
     correspond to private option names and values accepted by
     [FFmpeg](https://ffmpeg.org/) for the chosen codec specified by `codec_name`.
 - `swscale_options::OptionsT = (;)`: A `Namedtuple`, or `Dict{Symbol, Any}` of
-    settings for the swscale object used to perform color space scaling. Options
+    options for the swscale object used to perform color space scaling. Options
     must correspond with options for FFmpeg's
     [scaler](https://ffmpeg.org/ffmpeg-all.html#Scaler-Options) filter.
 - `target_pix_fmt::Union{Nothing, Cint} = nothing`: The pixel format that will
@@ -478,7 +478,7 @@ Create a video container `filename` and encode the set of frames `imgstack` into
 it. `imgstack` must be an iterable of matrices and each frame must have the same
 dimensions and element type.
 
-Encoding settings, restrictions on frame size and element type, and other
+Encoding options, restrictions on frame size and element type, and other
 details are described in [`open_video_out`](@ref). All keyword arguments are
 passed to `open_video_out`.
 

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -232,7 +232,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                      codec_name::Union{AbstractString, Nothing} = nothing,
                      framerate::Real = 24,
                      scanline_major::Bool = false,
-                     container_settings::SettingsT = (;),
+                     container_options::SettingsT = (;),
                      container_private_options::SettingsT = (;),
                      encoder_options::SettingsT = (;),
                      encoder_private_options::SettingsT = (;),
@@ -306,7 +306,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
         codec_context.flags |= AV_CODEC_FLAG_GLOBAL_HEADER
     end
 
-    set_class_options(format_context, container_settings)
+    set_class_options(format_context, container_options)
     if check_ptr_valid(format_context.oformat.priv_class, false)
         set_class_options(format_context.priv_data, container_private_options)
     elseif !isempty(container_private_options)
@@ -410,7 +410,7 @@ occurred.
     stride in the first dimension. For normal arrays, this corresponds to a
     matrix where frame width is in the first dimension, and frame height is in
     the second.
-- `container_settings::SettingsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}`
+- `container_options::SettingsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}`
     of settings for the container. Must correspond to option names and values
     accepted by [FFmpeg](https://ffmpeg.org/).
 - `container_private_options::SettingsT = (;)`: A `NamedTuple` or

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -1,5 +1,4 @@
-export open_video_out, append_encode_mux!,
-    close_video_out!, encode_mux_video, get_codec_name
+export open_video_out, append_encode_mux!, close_video_out!, get_codec_name
 
 mutable struct VideoWriter{T<:GraphType}
     format_context::AVFormatContextPtr
@@ -473,7 +472,7 @@ end
 img_params(img::AbstractMatrix{T}) where T = (T, size(img))
 
 """
-    encode_mux_video(filename::String, imgstack; ...)
+    save(filename::String, imgstack; ...)
 
 Create a video container `filename` and encode the set of frames `imgstack` into
 it. `imgstack` must be an iterable of matrices and each frame must have the same
@@ -486,7 +485,7 @@ passed to `open_video_out`.
 See also: [`open_video_out`](@ref), [`append_encode_mux!`](@ref),
 [`close_video_out!`](@ref)
 """
-function encode_mux_video(filename::String, imgstack; kwargs...)
+function save(filename::String, imgstack; kwargs...)
     open_video_out(filename, first(imgstack); kwargs...) do writer
         for (i, img) in enumerate(imgstack)
             _append_encode_mux!(writer, img, i - 1)

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -233,7 +233,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                      framerate::Real = 24,
                      scanline_major::Bool = false,
                      container_settings::SettingsT = (;),
-                     container_private_settings::SettingsT = (;),
+                     container_private_options::SettingsT = (;),
                      encoder_options::SettingsT = (;),
                      encoder_private_options::SettingsT = (;),
                      swscale_settings::SettingsT = (;),
@@ -308,8 +308,8 @@ function VideoWriter(filename::AbstractString, ::Type{T},
 
     set_class_options(format_context, container_settings)
     if check_ptr_valid(format_context.oformat.priv_class, false)
-        set_class_options(format_context.priv_data, container_private_settings)
-    elseif !isempty(container_private_settings)
+        set_class_options(format_context.priv_data, container_private_options)
+    elseif !isempty(container_private_options)
         @warn "This container format does not support private settings, and will be ignored"
     end
     set_class_options(codec_context, encoder_options)
@@ -413,7 +413,7 @@ occurred.
 - `container_settings::SettingsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}`
     of settings for the container. Must correspond to option names and values
     accepted by [FFmpeg](https://ffmpeg.org/).
-- `container_private_settings::SettingsT = (;)`: A `NamedTuple` or
+- `container_private_options::SettingsT = (;)`: A `NamedTuple` or
     `Dict{Symbol, Any}` of private settings for the container. Must correspond
     to private options names and values accepted by
     [FFmpeg](https://ffmpeg.org/) for the chosen container type.

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -235,7 +235,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                      container_settings::SettingsT = (;),
                      container_private_settings::SettingsT = (;),
                      encoder_options::SettingsT = (;),
-                     encoder_private_settings::SettingsT = (;),
+                     encoder_private_options::SettingsT = (;),
                      swscale_settings::SettingsT = (;),
                      target_pix_fmt::Union{Nothing, Cint} = nothing,
                      pix_fmt_loss_flags = 0,
@@ -247,7 +247,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
     if haskey(encoder_options, :priv_data)
         throw(ArgumentError("""The field `priv_data` is no longer supported. Either reorganize as a flat NamedTuple or Dict,
         i.e. encoder_options=(color_range=2, crf=\"0\", preset=\"medium\") to rely on auto routing of public and private
-        settings, or pass the private settings to `encoder_private_settings` explicitly"""))
+        settings, or pass the private settings to `encoder_private_options` explicitly"""))
     end
     if !is_eltype_transfer_supported(T)
         throw(ArgumentError("Encoding arrays with eltype $T not yet supported"))
@@ -313,7 +313,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
         @warn "This container format does not support private settings, and will be ignored"
     end
     set_class_options(codec_context, encoder_options)
-    set_class_options(codec_context.priv_data, encoder_private_settings)
+    set_class_options(codec_context.priv_data, encoder_private_options)
 
     sigatomic_begin()
     lock(VIO_LOCK)
@@ -420,7 +420,7 @@ occurred.
 - `encoder_options::SettingsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}` of
     settings for the encoder context. Must correspond to option names and values
     accepted by [FFmpeg](https://ffmpeg.org/).
-- `encoder_private_settings::SettingsT = (;)`: A `NamedTuple` or
+- `encoder_private_options::SettingsT = (;)`: A `NamedTuple` or
     `Dict{Symbol, Any}` of private settings for the encoder context. Must
     correspond to private option names and values accepted by
     [FFmpeg](https://ffmpeg.org/) for the chosen codec specified by `codec_name`.

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -234,7 +234,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                      scanline_major::Bool = false,
                      container_settings::SettingsT = (;),
                      container_private_settings::SettingsT = (;),
-                     encoder_settings::SettingsT = (;),
+                     encoder_options::SettingsT = (;),
                      encoder_private_settings::SettingsT = (;),
                      swscale_settings::SettingsT = (;),
                      target_pix_fmt::Union{Nothing, Cint} = nothing,
@@ -244,9 +244,9 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                      sws_color_details::SettingsT = (;)) where T
     framerate > 0 || error("Framerate must be strictly positive")
 
-    if haskey(encoder_settings, :priv_data)
+    if haskey(encoder_options, :priv_data)
         throw(ArgumentError("""The field `priv_data` is no longer supported. Either reorganize as a flat NamedTuple or Dict,
-        i.e. encoder_settings=(color_range=2, crf=\"0\", preset=\"medium\") to rely on auto routing of public and private
+        i.e. encoder_options=(color_range=2, crf=\"0\", preset=\"medium\") to rely on auto routing of public and private
         settings, or pass the private settings to `encoder_private_settings` explicitly"""))
     end
     if !is_eltype_transfer_supported(T)
@@ -312,7 +312,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
     elseif !isempty(container_private_settings)
         @warn "This container format does not support private settings, and will be ignored"
     end
-    set_class_options(codec_context, encoder_settings)
+    set_class_options(codec_context, encoder_options)
     set_class_options(codec_context.priv_data, encoder_private_settings)
 
     sigatomic_begin()
@@ -417,7 +417,7 @@ occurred.
     `Dict{Symbol, Any}` of private settings for the container. Must correspond
     to private options names and values accepted by
     [FFmpeg](https://ffmpeg.org/) for the chosen container type.
-- `encoder_settings::SettingsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}` of
+- `encoder_options::SettingsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}` of
     settings for the encoder context. Must correspond to option names and values
     accepted by [FFmpeg](https://ffmpeg.org/).
 - `encoder_private_settings::SettingsT = (;)`: A `NamedTuple` or

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -165,7 +165,7 @@ function create_encoding_frame_graph(transfer_pix_fmt, encoding_pix_fmt, width,
                                      dst_color_primaries, dst_color_trc,
                                      dst_colorspace, dst_color_range,
                                      use_vio_gray_transform, swscale_options;
-                                     sws_color_details::OptionsT = (;))
+                                     sws_color_options::OptionsT = (;))
     if use_vio_gray_transform
         frame_graph = GrayTransform()
         set_basic_frame_properties!(frame_graph.srcframe, width, height,
@@ -182,7 +182,7 @@ function create_encoding_frame_graph(transfer_pix_fmt, encoding_pix_fmt, width,
                                    transfer_colorspace_details.color_primaries,
                                    transfer_colorspace_details.color_range,
                                    encoding_pix_fmt, dst_color_primaries,
-                                   dst_color_range, sws_color_details,
+                                   dst_color_range, sws_color_options,
                                    swscale_options)
         set_basic_frame_properties!(frame_graph.srcframe, width, height,
                                     transfer_pix_fmt)
@@ -241,7 +241,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                      pix_fmt_loss_flags = 0,
                      input_colorspace_details = nothing,
                      allow_vio_gray_transform = true,
-                     sws_color_details::OptionsT = (;)) where T
+                     sws_color_options::OptionsT = (;)) where T
     framerate > 0 || error("Framerate must be strictly positive")
 
     if haskey(encoder_options, :priv_data)
@@ -357,8 +357,8 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                                               codec_context.color_range,
                                               use_vio_gray_transform,
                                               swscale_options;
-                                              sws_color_details =
-                                              sws_color_details)
+                                              sws_color_options =
+                                              sws_color_options)
     packet = AVPacketPtr()
 
     VideoWriter(format_context, codec_context, frame_graph, packet,
@@ -451,7 +451,7 @@ occurred.
 - `allow_vio_gray_transform = true`: Instead of using `sws_scale` for gray data,
     use a more accurate color space transformation implemented in `VideoIO` if
     `allow_vio_gray_transform = true`. Otherwise, use `sws_scale`.
-- `sws_color_details::OptionsT = (;)`: Additional keyword arguments passed to
+- `sws_color_options::OptionsT = (;)`: Additional keyword arguments passed to
     [sws_setColorspaceDetails]
     (http://ffmpeg.org/doxygen/2.5/group__libsws.html#ga541bdffa8149f5f9203664f955faa040).
 

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -165,7 +165,7 @@ function create_encoding_frame_graph(transfer_pix_fmt, encoding_pix_fmt, width,
                                      dst_color_primaries, dst_color_trc,
                                      dst_colorspace, dst_color_range,
                                      use_vio_gray_transform, swscale_settings;
-                                     sws_color_details::SettingsT = (;))
+                                     sws_color_details::OptionsT = (;))
     if use_vio_gray_transform
         frame_graph = GrayTransform()
         set_basic_frame_properties!(frame_graph.srcframe, width, height,
@@ -232,16 +232,16 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                      codec_name::Union{AbstractString, Nothing} = nothing,
                      framerate::Real = 24,
                      scanline_major::Bool = false,
-                     container_options::SettingsT = (;),
-                     container_private_options::SettingsT = (;),
-                     encoder_options::SettingsT = (;),
-                     encoder_private_options::SettingsT = (;),
-                     swscale_settings::SettingsT = (;),
+                     container_options::OptionsT = (;),
+                     container_private_options::OptionsT = (;),
+                     encoder_options::OptionsT = (;),
+                     encoder_private_options::OptionsT = (;),
+                     swscale_settings::OptionsT = (;),
                      target_pix_fmt::Union{Nothing, Cint} = nothing,
                      pix_fmt_loss_flags = 0,
                      input_colorspace_details = nothing,
                      allow_vio_gray_transform = true,
-                     sws_color_details::SettingsT = (;)) where T
+                     sws_color_details::OptionsT = (;)) where T
     framerate > 0 || error("Framerate must be strictly positive")
 
     if haskey(encoder_options, :priv_data)
@@ -410,21 +410,21 @@ occurred.
     stride in the first dimension. For normal arrays, this corresponds to a
     matrix where frame width is in the first dimension, and frame height is in
     the second.
-- `container_options::SettingsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}`
+- `container_options::OptionsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}`
     of settings for the container. Must correspond to option names and values
     accepted by [FFmpeg](https://ffmpeg.org/).
-- `container_private_options::SettingsT = (;)`: A `NamedTuple` or
+- `container_private_options::OptionsT = (;)`: A `NamedTuple` or
     `Dict{Symbol, Any}` of private settings for the container. Must correspond
     to private options names and values accepted by
     [FFmpeg](https://ffmpeg.org/) for the chosen container type.
-- `encoder_options::SettingsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}` of
+- `encoder_options::OptionsT = (;)`: A `NamedTuple` or `Dict{Symbol, Any}` of
     settings for the encoder context. Must correspond to option names and values
     accepted by [FFmpeg](https://ffmpeg.org/).
-- `encoder_private_options::SettingsT = (;)`: A `NamedTuple` or
+- `encoder_private_options::OptionsT = (;)`: A `NamedTuple` or
     `Dict{Symbol, Any}` of private settings for the encoder context. Must
     correspond to private option names and values accepted by
     [FFmpeg](https://ffmpeg.org/) for the chosen codec specified by `codec_name`.
-- `swscale_settings::SettingsT = (;)`: A `Namedtuple`, or `Dict{Symbol, Any}` of
+- `swscale_settings::OptionsT = (;)`: A `Namedtuple`, or `Dict{Symbol, Any}` of
     settings for the swscale object used to perform color space scaling. Options
     must correspond with options for FFmpeg's
     [scaler](https://ffmpeg.org/ffmpeg-all.html#Scaler-Options) filter.
@@ -451,7 +451,7 @@ occurred.
 - `allow_vio_gray_transform = true`: Instead of using `sws_scale` for gray data,
     use a more accurate color space transformation implemented in `VideoIO` if
     `allow_vio_gray_transform = true`. Otherwise, use `sws_scale`.
-- `sws_color_details::SettingsT = (;)`: Additional keyword arguments passed to
+- `sws_color_details::OptionsT = (;)`: Additional keyword arguments passed to
     [sws_setColorspaceDetails]
     (http://ffmpeg.org/doxygen/2.5/group__libsws.html#ga541bdffa8149f5f9203664f955faa040).
 

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -164,7 +164,7 @@ function create_encoding_frame_graph(transfer_pix_fmt, encoding_pix_fmt, width,
                                      height, transfer_colorspace_details,
                                      dst_color_primaries, dst_color_trc,
                                      dst_colorspace, dst_color_range,
-                                     use_vio_gray_transform, swscale_settings;
+                                     use_vio_gray_transform, swscale_options;
                                      sws_color_details::OptionsT = (;))
     if use_vio_gray_transform
         frame_graph = GrayTransform()
@@ -183,7 +183,7 @@ function create_encoding_frame_graph(transfer_pix_fmt, encoding_pix_fmt, width,
                                    transfer_colorspace_details.color_range,
                                    encoding_pix_fmt, dst_color_primaries,
                                    dst_color_range, sws_color_details,
-                                   swscale_settings)
+                                   swscale_options)
         set_basic_frame_properties!(frame_graph.srcframe, width, height,
                                     transfer_pix_fmt)
     end
@@ -236,7 +236,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                      container_private_options::OptionsT = (;),
                      encoder_options::OptionsT = (;),
                      encoder_private_options::OptionsT = (;),
-                     swscale_settings::OptionsT = (;),
+                     swscale_options::OptionsT = (;),
                      target_pix_fmt::Union{Nothing, Cint} = nothing,
                      pix_fmt_loss_flags = 0,
                      input_colorspace_details = nothing,
@@ -356,7 +356,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                                               codec_context.colorspace,
                                               codec_context.color_range,
                                               use_vio_gray_transform,
-                                              swscale_settings;
+                                              swscale_options;
                                               sws_color_details =
                                               sws_color_details)
     packet = AVPacketPtr()
@@ -424,7 +424,7 @@ occurred.
     `Dict{Symbol, Any}` of private settings for the encoder context. Must
     correspond to private option names and values accepted by
     [FFmpeg](https://ffmpeg.org/) for the chosen codec specified by `codec_name`.
-- `swscale_settings::OptionsT = (;)`: A `Namedtuple`, or `Dict{Symbol, Any}` of
+- `swscale_options::OptionsT = (;)`: A `Namedtuple`, or `Dict{Symbol, Any}` of
     settings for the swscale object used to perform color space scaling. Options
     must correspond with options for FFmpeg's
     [scaler](https://ffmpeg.org/ffmpeg-all.html#Scaler-Options) filter.

--- a/src/frame_graph.jl
+++ b/src/frame_graph.jl
@@ -17,7 +17,7 @@ end
 
 function SwsTransform(src_w, src_h, src_pix_fmt, src_primaries, src_color_range,
                       dst_w, dst_h, dst_pix_fmt, dst_primaries, dst_color_range,
-                      sws_color_details, sws_scale_options)
+                      sws_color_options, sws_scale_options)
     sws_context = SwsContextPtr()
     sws_options = Dict(:srcw       => string(src_w),
                        :srch       => string(src_h),
@@ -45,7 +45,7 @@ function SwsTransform(src_w, src_h, src_pix_fmt, src_primaries, src_color_range,
                                    src_range = src_color_range,
                                    table = table,
                                    dst_range = dst_color_range,
-                                   sws_color_details...)
+                                   sws_color_options...)
     ret || error("Could not set sws color details")
 
     srcframe = AVFramePtr()
@@ -54,11 +54,11 @@ function SwsTransform(src_w, src_h, src_pix_fmt, src_primaries, src_color_range,
 end
 
 function SwsTransform(src_w, src_h, src_pix_fmt, src_primaries, src_color_range,
-             dst_pix_fmt, dst_primaries, dst_color_range, sws_color_details,
+             dst_pix_fmt, dst_primaries, dst_color_range, sws_color_options,
                       sws_scale_options)
     SwsTransform(src_w, src_h, src_pix_fmt, src_primaries, src_color_range,
                  src_w, src_h, dst_pix_fmt, dst_primaries, dst_color_range,
-                 sws_color_details, sws_scale_options)
+                 sws_color_options, sws_scale_options)
 end
 
 mutable struct GrayTransform

--- a/src/frame_graph.jl
+++ b/src/frame_graph.jl
@@ -17,7 +17,7 @@ end
 
 function SwsTransform(src_w, src_h, src_pix_fmt, src_primaries, src_color_range,
                       dst_w, dst_h, dst_pix_fmt, dst_primaries, dst_color_range,
-                      sws_color_details, sws_scale_settings)
+                      sws_color_details, sws_scale_options)
     sws_context = SwsContextPtr()
     sws_options = Dict(:srcw       => string(src_w),
                        :srch       => string(src_h),
@@ -25,14 +25,14 @@ function SwsTransform(src_w, src_h, src_pix_fmt, src_primaries, src_color_range,
                        :dstw       => string(dst_w),
                        :dsth       => string(dst_h),
                        :dst_format => string(dst_pix_fmt))
-    for (key, val) in pairs(sws_scale_settings)
+    for (key, val) in pairs(sws_scale_options)
         sws_options[key] = string(val)
     end
     if sws_options[:srcw] != string(src_w) ||
         sws_options[:dstw] != string(dst_w) ||
         sws_options[:srch] != string(src_h) ||
         sws_options[:dsth] != string(dst_h)
-        throw(ArgumentError("Changing pixel dimensions with sws_scale_settings not yet supported"))
+        throw(ArgumentError("Changing pixel dimensions with sws_scale_options not yet supported"))
     end
     set_class_options(sws_context, sws_options)
     ret = sws_init_context(sws_context, C_NULL, C_NULL)
@@ -55,10 +55,10 @@ end
 
 function SwsTransform(src_w, src_h, src_pix_fmt, src_primaries, src_color_range,
              dst_pix_fmt, dst_primaries, dst_color_range, sws_color_details,
-                      sws_scale_settings)
+                      sws_scale_options)
     SwsTransform(src_w, src_h, src_pix_fmt, src_primaries, src_color_range,
                  src_w, src_h, dst_pix_fmt, dst_primaries, dst_color_range,
-                 sws_color_details, sws_scale_settings)
+                 sws_color_details, sws_scale_options)
 end
 
 mutable struct GrayTransform

--- a/test/accuracy.jl
+++ b/test/accuracy.jl
@@ -3,8 +3,8 @@
     imgstack_rgb = VideoIO.openvideo(collect, file)
     imgstack_gray = convert.(Array{Gray{N0f8}}, imgstack_rgb)
     @testset "Lossless Grayscale encoding" begin
-        encoder_settings = (color_range=2, crf=0, preset="medium")
-        VideoIO.save(tempvidpath, imgstack_gray, codec_name = "libx264", encoder_settings = encoder_settings)
+        encoder_options = (color_range=2, crf=0, preset="medium")
+        VideoIO.save(tempvidpath, imgstack_gray, codec_name = "libx264", encoder_options = encoder_options)
         imgstack_gray_copy = VideoIO.openvideo(collect, tempvidpath, target_format = VideoIO.AV_PIX_FMT_GRAY8)
         @test eltype(eltype(imgstack_gray)) == eltype(eltype(imgstack_gray_copy))
         @test length(imgstack_gray) == length(imgstack_gray_copy)
@@ -13,9 +13,9 @@
     end
 
     @testset "Lossless RGB encoding" begin
-        encoder_settings = (color_range=2, crf=0, preset="medium")
+        encoder_options = (color_range=2, crf=0, preset="medium")
         codec_name="libx264rgb"
-        VideoIO.save(tempvidpath, imgstack_rgb, codec_name = codec_name, encoder_settings = encoder_settings)
+        VideoIO.save(tempvidpath, imgstack_rgb, codec_name = codec_name, encoder_options = encoder_options)
         imgstack_rgb_copy = VideoIO.openvideo(collect, tempvidpath)
         @test eltype(imgstack_rgb) == eltype(imgstack_rgb_copy)
         @test length(imgstack_rgb) == length(imgstack_rgb_copy)
@@ -42,8 +42,8 @@
             push!(imgstack,img)
         end
 
-        encoder_settings = (color_range=2, crf=0, preset="medium")
-        VideoIO.save(tempvidpath, imgstack, encoder_settings = encoder_settings)
+        encoder_options = (color_range=2, crf=0, preset="medium")
+        VideoIO.save(tempvidpath, imgstack, encoder_options = encoder_options)
         f = VideoIO.openvideo(tempvidpath, target_format = VideoIO.AV_PIX_FMT_GRAY8)
         try
             frame_test = collect(rawview(channelview(read(f))))
@@ -75,8 +75,8 @@
                 push!(imgstack,fill(UInt8(i),(16,16)))
             end
 
-            encoder_settings = (color_range=2, crf=0, preset="medium")
-            VideoIO.save(tempvidpath, imgstack, encoder_settings = encoder_settings)
+            encoder_options = (color_range=2, crf=0, preset="medium")
+            VideoIO.save(tempvidpath, imgstack, encoder_options = encoder_options)
             f = VideoIO.openvideo(tempvidpath, target_format = VideoIO.AV_PIX_FMT_GRAY8)
             try
                 frame_ids_test = []

--- a/test/accuracy.jl
+++ b/test/accuracy.jl
@@ -3,7 +3,7 @@
     imgstack_rgb = VideoIO.openvideo(collect, file)
     imgstack_gray = convert.(Array{Gray{N0f8}}, imgstack_rgb)
     @testset "Lossless Grayscale encoding" begin
-        encoder_settings = (color_range=2, crf="0", preset="medium")
+        encoder_settings = (color_range=2, crf=0, preset="medium")
         VideoIO.save(tempvidpath, imgstack_gray, codec_name = "libx264", encoder_settings = encoder_settings)
         imgstack_gray_copy = VideoIO.openvideo(collect, tempvidpath, target_format = VideoIO.AV_PIX_FMT_GRAY8)
         @test eltype(eltype(imgstack_gray)) == eltype(eltype(imgstack_gray_copy))
@@ -13,7 +13,7 @@
     end
 
     @testset "Lossless RGB encoding" begin
-        encoder_settings = (color_range=2, crf="0", preset="medium")
+        encoder_settings = (color_range=2, crf=0, preset="medium")
         codec_name="libx264rgb"
         VideoIO.save(tempvidpath, imgstack_rgb, codec_name = codec_name, encoder_settings = encoder_settings)
         imgstack_rgb_copy = VideoIO.openvideo(collect, tempvidpath)
@@ -42,7 +42,7 @@
             push!(imgstack,img)
         end
 
-        encoder_settings = (color_range=2, crf="0", preset="medium")
+        encoder_settings = (color_range=2, crf=0, preset="medium")
         VideoIO.save(tempvidpath, imgstack, encoder_settings = encoder_settings)
         f = VideoIO.openvideo(tempvidpath, target_format = VideoIO.AV_PIX_FMT_GRAY8)
         try
@@ -75,7 +75,7 @@
                 push!(imgstack,fill(UInt8(i),(16,16)))
             end
 
-            encoder_settings = (color_range=2, crf="0", preset="medium")
+            encoder_settings = (color_range=2, crf=0, preset="medium")
             VideoIO.save(tempvidpath, imgstack, encoder_settings = encoder_settings)
             f = VideoIO.openvideo(tempvidpath, target_format = VideoIO.AV_PIX_FMT_GRAY8)
             try

--- a/test/accuracy.jl
+++ b/test/accuracy.jl
@@ -4,7 +4,7 @@
     imgstack_gray = convert.(Array{Gray{N0f8}}, imgstack_rgb)
     @testset "Lossless Grayscale encoding" begin
         encoder_settings = (color_range=2, crf="0", preset="medium")
-        VideoIO.encode_mux_video(tempvidpath, imgstack_gray, codec_name = "libx264", encoder_settings = encoder_settings)
+        VideoIO.save(tempvidpath, imgstack_gray, codec_name = "libx264", encoder_settings = encoder_settings)
         imgstack_gray_copy = VideoIO.openvideo(collect, tempvidpath, target_format = VideoIO.AV_PIX_FMT_GRAY8)
         @test eltype(eltype(imgstack_gray)) == eltype(eltype(imgstack_gray_copy))
         @test length(imgstack_gray) == length(imgstack_gray_copy)
@@ -15,7 +15,7 @@
     @testset "Lossless RGB encoding" begin
         encoder_settings = (color_range=2, crf="0", preset="medium")
         codec_name="libx264rgb"
-        VideoIO.encode_mux_video(tempvidpath, imgstack_rgb, codec_name = codec_name, encoder_settings = encoder_settings)
+        VideoIO.save(tempvidpath, imgstack_rgb, codec_name = codec_name, encoder_settings = encoder_settings)
         imgstack_rgb_copy = VideoIO.openvideo(collect, tempvidpath)
         @test eltype(imgstack_rgb) == eltype(imgstack_rgb_copy)
         @test length(imgstack_rgb) == length(imgstack_rgb_copy)
@@ -43,7 +43,7 @@
         end
 
         encoder_settings = (color_range=2, crf="0", preset="medium")
-        VideoIO.encode_mux_video(tempvidpath, imgstack, encoder_settings = encoder_settings)
+        VideoIO.save(tempvidpath, imgstack, encoder_settings = encoder_settings)
         f = VideoIO.openvideo(tempvidpath, target_format = VideoIO.AV_PIX_FMT_GRAY8)
         try
             frame_test = collect(rawview(channelview(read(f))))
@@ -76,7 +76,7 @@
             end
 
             encoder_settings = (color_range=2, crf="0", preset="medium")
-            VideoIO.encode_mux_video(tempvidpath, imgstack, encoder_settings = encoder_settings)
+            VideoIO.save(tempvidpath, imgstack, encoder_settings = encoder_settings)
             f = VideoIO.openvideo(tempvidpath, target_format = VideoIO.AV_PIX_FMT_GRAY8)
             try
                 frame_ids_test = []

--- a/test/reading.jl
+++ b/test/reading.jl
@@ -1,5 +1,5 @@
 @testset "Reading of various example file formats" begin
-    swscale_settings = (sws_flags = "accurate_rnd+full_chroma_inp+full_chroma_int",)
+    swscale_options = (sws_flags = "accurate_rnd+full_chroma_inp+full_chroma_int",)
     for testvid in values(VideoIO.TestVideos.videofiles)
         name = testvid.name
         test_frameno = testvid.testframe
@@ -7,7 +7,7 @@
             testvid_path = joinpath(@__DIR__, "../videos", name)
             comparison_frame = make_comparison_frame_png(load, testvid_path, test_frameno)
             f = VideoIO.testvideo(testvid_path)
-            v = VideoIO.openvideo(f; swscale_settings = swscale_settings)
+            v = VideoIO.openvideo(f; swscale_options = swscale_options)
             try
                 time_seconds = VideoIO.gettime(v)
                 @test time_seconds == 0
@@ -142,7 +142,7 @@ end
 end
 
 @testset "IO reading of various example file formats" begin
-    swscale_settings = (sws_flags = "accurate_rnd+full_chroma_inp+full_chroma_int",)
+    swscale_options = (sws_flags = "accurate_rnd+full_chroma_inp+full_chroma_int",)
     for testvid in values(VideoIO.TestVideos.videofiles)
         name = testvid.name
         test_frameno = testvid.testframe
@@ -152,7 +152,7 @@ end
             testvid_path = joinpath(@__DIR__, "../videos", name)
             comparison_frame = make_comparison_frame_png(load, testvid_path, test_frameno)
             filename = joinpath(videodir, name)
-            v = VideoIO.openvideo(filename; swscale_settings = swscale_settings)
+            v = VideoIO.openvideo(filename; swscale_options = swscale_options)
             try
                 width, height = VideoIO.out_frame_size(v)
                 if size(comparison_frame, 1) > height

--- a/test/writing.jl
+++ b/test/writing.jl
@@ -3,7 +3,7 @@
         @testset "Encoding $el imagestack" begin
             n = 100
             imgstack = map(x->rand(el,100,100),1:n)
-            encoder_settings = (color_range=2, crf="0", preset="medium")
+            encoder_settings = (color_range=2, crf=0, preset="medium")
             VideoIO.save(tempvidpath, imgstack, framerate = 30, encoder_settings = encoder_settings)
             @test stat(tempvidpath).size > 100
             @test VideoIO.openvideo(VideoIO.counttotalframes, tempvidpath) == n
@@ -165,7 +165,7 @@ end
     target_dur = 3.39
     @testset "Encoding with frame rate $(float(fr))" begin
         imgstack = map(x->rand(UInt8,100,100),1:n)
-        encoder_settings = (color_range=2, crf="0", preset="medium")
+        encoder_settings = (color_range=2, crf=0, preset="medium")
         VideoIO.save(tempvidpath, imgstack, framerate = fr, encoder_settings = encoder_settings)
         @test stat(tempvidpath).size > 100
         measured_dur_str = VideoIO.FFMPEG.exe(`-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 $(tempvidpath)`, command = VideoIO.FFMPEG.ffprobe, collect = true)
@@ -179,7 +179,7 @@ end
     target_dur = 3.39
     @testset "Encoding with frame rate $(float(fr))" begin
         imgstack = map(x->rand(UInt8,100,100),1:n)
-        encoder_settings = (color_range=2, crf="0", preset="medium")
+        encoder_settings = (color_range=2, crf=0, preset="medium")
         VideoIO.save(tempvidpath, imgstack, framerate = fr, encoder_settings = encoder_settings)
         @test stat(tempvidpath).size > 100
         measured_dur_str = VideoIO.FFMPEG.exe(`-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 $(tempvidpath)`, command = VideoIO.FFMPEG.ffprobe, collect = true)

--- a/test/writing.jl
+++ b/test/writing.jl
@@ -14,7 +14,7 @@ end
 @testset "Simultaneous encoding and muxing" begin
     n = 100
     encoder_options = (color_range = 2,)
-    container_private_settings = (movflags = "+write_colr",)
+    container_private_options = (movflags = "+write_colr",)
     for el in [Gray{N0f8}, Gray{N6f10}, RGB{N0f8}, RGB{N6f10}]
         codec_name = el <: RGB ? "libx264rgb" : "libx264" # the former is necessary for lossless RGB
         for scanline_arg in [true, false]
@@ -26,7 +26,7 @@ end
                                          codec_name = codec_name,
                                          encoder_private_options = encoder_private_options,
                                          encoder_options = encoder_options,
-                                         container_private_settings = container_private_settings,
+                                         container_private_options = container_private_options,
                                          scanline_major = scanline_arg)
                 @test stat(tempvidpath).size > 100
                 f = VideoIO.openvideo(tempvidpath, target_format = VideoIO.get_transfer_pix_fmt(el))

--- a/test/writing.jl
+++ b/test/writing.jl
@@ -20,11 +20,11 @@ end
         for scanline_arg in [true, false]
             @testset "Encoding $el imagestack, scanline_major = $scanline_arg" begin
                 img_stack = map(x -> rand(el, 100, 100), 1 : n)
-                encoder_private_settings = (crf = 0, preset = "medium")
+                encoder_private_options = (crf = 0, preset = "medium")
                 VideoIO.save(tempvidpath,
                                          img_stack;
                                          codec_name = codec_name,
-                                         encoder_private_settings = encoder_private_settings,
+                                         encoder_private_options = encoder_private_options,
                                          encoder_options = encoder_options,
                                          container_private_settings = container_private_settings,
                                          scanline_major = scanline_arg)
@@ -105,7 +105,7 @@ end
 end
 
 @testset "Encoding monochrome videos" begin
-    encoder_private_settings = (crf = 0, preset = "fast")
+    encoder_private_options = (crf = 0, preset = "fast")
     nw = nh = 100
     nf = 5
     for elt in (N0f8, N6f10)
@@ -126,8 +126,8 @@ end
         # Test that full-range input is automatically converted to limited range
         VideoIO.save(tempvidpath, img_stack_full_range,
                                  target_pix_fmt = target_fmt,
-                                 encoder_private_settings =
-                                 encoder_private_settings)
+                                 encoder_private_options =
+                                 encoder_private_options)
 
         minp, maxp = get_raw_luma_extrema(elt, tempvidpath, nw, nh)
         @test minp > full_min
@@ -136,8 +136,8 @@ end
         # Test that this conversion is NOT done if output video is full range
         VideoIO.save(tempvidpath, img_stack_full_range,
                                  target_pix_fmt = target_fmt,
-                                 encoder_private_settings =
-                                 encoder_private_settings,
+                                 encoder_private_options =
+                                 encoder_private_options,
                                  encoder_options = (color_range = 2,))
         minp, maxp = get_raw_luma_extrema(elt, tempvidpath, nw, nh)
         @test minp == full_min
@@ -149,8 +149,8 @@ end
                                                    limited_max)
         VideoIO.save(tempvidpath, img_stack_limited_range,
                                  target_pix_fmt = target_fmt,
-                                 encoder_private_settings =
-                                 encoder_private_settings,
+                                 encoder_private_options =
+                                 encoder_private_options,
                                  input_colorspace_details =
                                  VideoIO.VioColorspaceDetails())
         minp, maxp = get_raw_luma_extrema(elt, tempvidpath, nw, nh)

--- a/test/writing.jl
+++ b/test/writing.jl
@@ -3,8 +3,8 @@
         @testset "Encoding $el imagestack" begin
             n = 100
             imgstack = map(x->rand(el,100,100),1:n)
-            encoder_settings = (color_range=2, crf=0, preset="medium")
-            VideoIO.save(tempvidpath, imgstack, framerate = 30, encoder_settings = encoder_settings)
+            encoder_options = (color_range=2, crf=0, preset="medium")
+            VideoIO.save(tempvidpath, imgstack, framerate = 30, encoder_options = encoder_options)
             @test stat(tempvidpath).size > 100
             @test VideoIO.openvideo(VideoIO.counttotalframes, tempvidpath) == n
         end
@@ -13,7 +13,7 @@ end
 
 @testset "Simultaneous encoding and muxing" begin
     n = 100
-    encoder_settings = (color_range = 2,)
+    encoder_options = (color_range = 2,)
     container_private_settings = (movflags = "+write_colr",)
     for el in [Gray{N0f8}, Gray{N6f10}, RGB{N0f8}, RGB{N6f10}]
         codec_name = el <: RGB ? "libx264rgb" : "libx264" # the former is necessary for lossless RGB
@@ -25,7 +25,7 @@ end
                                          img_stack;
                                          codec_name = codec_name,
                                          encoder_private_settings = encoder_private_settings,
-                                         encoder_settings = encoder_settings,
+                                         encoder_options = encoder_options,
                                          container_private_settings = container_private_settings,
                                          scanline_major = scanline_arg)
                 @test stat(tempvidpath).size > 100
@@ -138,7 +138,7 @@ end
                                  target_pix_fmt = target_fmt,
                                  encoder_private_settings =
                                  encoder_private_settings,
-                                 encoder_settings = (color_range = 2,))
+                                 encoder_options = (color_range = 2,))
         minp, maxp = get_raw_luma_extrema(elt, tempvidpath, nw, nh)
         @test minp == full_min
         @test maxp == full_max
@@ -165,8 +165,8 @@ end
     target_dur = 3.39
     @testset "Encoding with frame rate $(float(fr))" begin
         imgstack = map(x->rand(UInt8,100,100),1:n)
-        encoder_settings = (color_range=2, crf=0, preset="medium")
-        VideoIO.save(tempvidpath, imgstack, framerate = fr, encoder_settings = encoder_settings)
+        encoder_options = (color_range=2, crf=0, preset="medium")
+        VideoIO.save(tempvidpath, imgstack, framerate = fr, encoder_options = encoder_options)
         @test stat(tempvidpath).size > 100
         measured_dur_str = VideoIO.FFMPEG.exe(`-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 $(tempvidpath)`, command = VideoIO.FFMPEG.ffprobe, collect = true)
         @test parse(Float64, measured_dur_str[1]) == target_dur
@@ -179,8 +179,8 @@ end
     target_dur = 3.39
     @testset "Encoding with frame rate $(float(fr))" begin
         imgstack = map(x->rand(UInt8,100,100),1:n)
-        encoder_settings = (color_range=2, crf=0, preset="medium")
-        VideoIO.save(tempvidpath, imgstack, framerate = fr, encoder_settings = encoder_settings)
+        encoder_options = (color_range=2, crf=0, preset="medium")
+        VideoIO.save(tempvidpath, imgstack, framerate = fr, encoder_options = encoder_options)
         @test stat(tempvidpath).size > 100
         measured_dur_str = VideoIO.FFMPEG.exe(`-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 $(tempvidpath)`, command = VideoIO.FFMPEG.ffprobe, collect = true)
         @test parse(Float64, measured_dur_str[1]) == target_dur

--- a/test/writing.jl
+++ b/test/writing.jl
@@ -4,7 +4,7 @@
             n = 100
             imgstack = map(x->rand(el,100,100),1:n)
             encoder_settings = (color_range=2, crf="0", preset="medium")
-            VideoIO.encode_mux_video(tempvidpath, imgstack, framerate = 30, encoder_settings = encoder_settings)
+            VideoIO.save(tempvidpath, imgstack, framerate = 30, encoder_settings = encoder_settings)
             @test stat(tempvidpath).size > 100
             @test VideoIO.openvideo(VideoIO.counttotalframes, tempvidpath) == n
         end
@@ -21,7 +21,7 @@ end
             @testset "Encoding $el imagestack, scanline_major = $scanline_arg" begin
                 img_stack = map(x -> rand(el, 100, 100), 1 : n)
                 encoder_private_settings = (crf = 0, preset = "medium")
-                VideoIO.encode_mux_video(tempvidpath,
+                VideoIO.save(tempvidpath,
                                          img_stack;
                                          codec_name = codec_name,
                                          encoder_private_settings = encoder_private_settings,
@@ -124,7 +124,7 @@ end
         end
         img_stack_full_range = make_test_tones(elt, nw, nh, nf)
         # Test that full-range input is automatically converted to limited range
-        VideoIO.encode_mux_video(tempvidpath, img_stack_full_range,
+        VideoIO.save(tempvidpath, img_stack_full_range,
                                  target_pix_fmt = target_fmt,
                                  encoder_private_settings =
                                  encoder_private_settings)
@@ -134,7 +134,7 @@ end
         @test maxp < full_max
 
         # Test that this conversion is NOT done if output video is full range
-        VideoIO.encode_mux_video(tempvidpath, img_stack_full_range,
+        VideoIO.save(tempvidpath, img_stack_full_range,
                                  target_pix_fmt = target_fmt,
                                  encoder_private_settings =
                                  encoder_private_settings,
@@ -147,7 +147,7 @@ end
         img_stack_limited_range = make_test_tones(elt, nw, nh, nf,
                                                    limited_min,
                                                    limited_max)
-        VideoIO.encode_mux_video(tempvidpath, img_stack_limited_range,
+        VideoIO.save(tempvidpath, img_stack_limited_range,
                                  target_pix_fmt = target_fmt,
                                  encoder_private_settings =
                                  encoder_private_settings,
@@ -166,7 +166,7 @@ end
     @testset "Encoding with frame rate $(float(fr))" begin
         imgstack = map(x->rand(UInt8,100,100),1:n)
         encoder_settings = (color_range=2, crf="0", preset="medium")
-        VideoIO.encode_mux_video(tempvidpath, imgstack, framerate = fr, encoder_settings = encoder_settings)
+        VideoIO.save(tempvidpath, imgstack, framerate = fr, encoder_settings = encoder_settings)
         @test stat(tempvidpath).size > 100
         measured_dur_str = VideoIO.FFMPEG.exe(`-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 $(tempvidpath)`, command = VideoIO.FFMPEG.ffprobe, collect = true)
         @test parse(Float64, measured_dur_str[1]) == target_dur
@@ -180,7 +180,7 @@ end
     @testset "Encoding with frame rate $(float(fr))" begin
         imgstack = map(x->rand(UInt8,100,100),1:n)
         encoder_settings = (color_range=2, crf="0", preset="medium")
-        VideoIO.encode_mux_video(tempvidpath, imgstack, framerate = fr, encoder_settings = encoder_settings)
+        VideoIO.save(tempvidpath, imgstack, framerate = fr, encoder_settings = encoder_settings)
         @test stat(tempvidpath).size > 100
         measured_dur_str = VideoIO.FFMPEG.exe(`-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 $(tempvidpath)`, command = VideoIO.FFMPEG.ffprobe, collect = true)
         @test parse(Float64, measured_dur_str[1]) == target_dur

--- a/util/lossless_video_encoding_testing.jl
+++ b/util/lossless_video_encoding_testing.jl
@@ -22,7 +22,7 @@ function createtestvideo(;filename::String="$(tempname()).mp4",duration::Real=5,
 end
 
 function testvideocomp!(df,preset,imgstack_gray)
-    t = @elapsed encode_mux_video("video.mp4",imgstack_gray,framerate=30,codec_name = "libx264",
+    t = @elapsed VideoIO.save("video.mp4",imgstack_gray,framerate=30,codec_name = "libx264",
                                     encoder_settings=(color_range=2, crf="0", "preset"=preset))
     fs = filesize("video.mp4")
     f = openvideo("video.mp4",target_format=VideoIO.AV_PIX_FMT_GRAY8)
@@ -85,7 +85,7 @@ df_ladybird_summary = by(df_ladybird, :preset, identical = :identical => minimum
 @show df_ladybird_summary
 
 ### Results (generated 2019-05-29 on a 2019 Macbook Pro)
-### OUTDATED. Generated before change to encode_mux_video
+### OUTDATED. Generated before change to VideoIO.save
 #=
 df_noise_summary = 9×6 DataFrame
 │ Row │ preset    │ identical │ fps_mean │ fps_std │ filesize_perc_mean │ filesize_perc_std │

--- a/util/lossless_video_encoding_testing.jl
+++ b/util/lossless_video_encoding_testing.jl
@@ -23,7 +23,7 @@ end
 
 function testvideocomp!(df,preset,imgstack_gray)
     t = @elapsed VideoIO.save("video.mp4",imgstack_gray,framerate=30,codec_name = "libx264",
-                                    encoder_settings=(color_range=2, crf="0", "preset"=preset))
+                                    encoder_settings=(color_range=2, crf=0, "preset"=preset))
     fs = filesize("video.mp4")
     f = openvideo("video.mp4",target_format=VideoIO.AV_PIX_FMT_GRAY8)
     imgstack_gray_copy = []

--- a/util/lossless_video_encoding_testing.jl
+++ b/util/lossless_video_encoding_testing.jl
@@ -23,7 +23,7 @@ end
 
 function testvideocomp!(df,preset,imgstack_gray)
     t = @elapsed VideoIO.save("video.mp4",imgstack_gray,framerate=30,codec_name = "libx264",
-                                    encoder_settings=(color_range=2, crf=0, "preset"=preset))
+                                    encoder_options=(color_range=2, crf=0, "preset"=preset))
     fs = filesize("video.mp4")
     f = openvideo("video.mp4",target_format=VideoIO.AV_PIX_FMT_GRAY8)
     imgstack_gray_copy = []


### PR DESCRIPTION
@galenlynch if we rename `container_settings`->`container_options` do we also want to:

change
```
 container_settings::SettingsT = (;),
 container_private_settings::SettingsT = (;),
 encoder_settings::SettingsT = (;),
 encoder_private_settings::SettingsT = (;),
```

to

```
 container_options::OptionsT = (;),
 container_private_options::OptionsT = (;),
 encoder_options::OptionsT = (;),
 encoder_private_options::OptionsT = (;),
```

Note `OptionsT`