### PR TITLE
append_encode_mux! -> Base.write, and simplify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ VideoIO v0.9 Release Notes
 ======================
 ## New features
 
+- New `VideoIO.load(filename::String; ...)` function to read entire video into memory
 
 ## Bugfixes
 - Encoding videos now encodes the correct number of frames
@@ -78,3 +79,30 @@ end
 ```
 Note that the multiplexing (mux) is now done in parallel with the encoding loop, so no need for an intermediate
 ".stream" file. Lower level functions should be used for more elaborate encoding/multiplexing tasks.
+
+### Performance improvement
+
+The speed of encoding `UInt8` frames losslessly has more than doubled.
+And.. encoding no longer has verbose printing.
+
+For `imgstack = map(x-> rand(UInt8, 2048, 1536), 1:100)`
+
+v0.8.4
+```julia
+julia> props = [:color_range=>2, :priv_data => ("crf"=>"0","preset"=>"ultrafast")];
+
+julia> @btime encodevideo("video.mp4", imgstack, AVCodecContextProperties = props)
+Progress: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:01
+[ Info: Video file saved: /Users/ian/video.mp4
+frame=  100 fps= 39 q=-1.0 Lsize=  480574kB time=00:00:04.12 bitrate=954382.6kbits/s speed= 1.6x    77x
+[ Info: video:480572kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.000459%
+... # hiding 6 subsequent repeated outputs
+  4.163 s (2205 allocations: 340.28 KiB)
+"video.mp4"
+```
+
+v0.9.0
+```julia
+julia> @btime VideoIO.save("video.mp4", imgstack, encoder_options = (color_range=2,crf=0,preset="ultrafast"))
+  1.888 s (445 allocations: 7.22 KiB)
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+VideoIO v0.9 Release Notes
+======================
+## New features
+
+
+## Bugfixes
+- Encoding videos now encodes the correct number of frames
+
+
+## Breaking Changes
+
+The encoding API has been renamed and simplified:
+
+### Single-shot encoding
+Before:
+```julia
+using VideoIO
+props = [:priv_data => ("crf"=>"22","preset"=>"medium")]
+encodevideo("video.mp4", imgstack, framerate=30, AVCodecContextProperties=props)
+```
+
+v0.9:
+```julia
+using VideoIO
+encoder_options = (crf=23, preset="medium")
+VideoIO.save("video.mp4", imgstack, framerate=30, encoder_options=encoder_options)
+```
+
+Note that `save` is not exported.
+Also note that the encoder options are now provided as a named tuple.
+
+VideoIO will automatically attempt to route these options between the public and private ffmpeg options, so for instance
+it is possible to specify lossless settings as:
+```julia
+VideoIO.save("video.mp4", imgstack, framerate=30,
+            encoder_options=(color_range=2, crf=0, preset="medium")
+            )
+```
+
+however the most fail-safe way would be to specify the public and private options specifically
+```julia
+VideoIO.save("video.mp4", imgstack, framerate=30,
+            encoder_options=(color_range=2),
+            encoder_private_options=(crf=0, preset="medium")
+            )
+```
+
+### Iterative encoding
+
+Before:
+```julia
+framestack = map(x->rand(UInt8, 100, 100), 1:100) #vector of 2D arrays
+
+using VideoIO
+props = [:priv_data => ("crf"=>"22","preset"=>"medium")]
+encoder = prepareencoder(first(framestack), framerate=24, AVCodecContextProperties=props)
+open("temp.stream", "w") do io
+    for i in eachindex(framestack)
+        appendencode!(encoder, io, framestack[i], i)
+    end
+    finishencode!(encoder, io)
+end
+
+mux("temp.stream", "video.mp4", framerate) #Multiplexes the stream into a video container
+```
+
+v0.9:
+```julia
+framestack = map(x->rand(UInt8, 100, 100), 1:100) #vector of 2D arrays
+
+using VideoIO
+encoder_options = (crf=23, preset="medium")
+open_video_out("video.mp4", first(framestack), framerate=30, encoder_options=encoder_options) do writer
+    for frame in framstack
+        push!(writer, frame)
+    end
+end
+```
+Note that the multiplexing (mux) is done in parallel with the encoding loop, so no need for an intermediate
+".stream" file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,10 @@ framestack = map(x->rand(UInt8, 100, 100), 1:100) #vector of 2D arrays
 using VideoIO
 encoder_options = (crf=23, preset="medium")
 open_video_out("video.mp4", first(framestack), framerate=30, encoder_options=encoder_options) do writer
-    for frame in framstack
-        push!(writer, frame)
+    for frame in framestack
+        write(writer, frame)
     end
 end
 ```
-Note that the multiplexing (mux) is done in parallel with the encoding loop, so no need for an intermediate
-".stream" file.
+Note that the multiplexing (mux) is now done in parallel with the encoding loop, so no need for an intermediate
+".stream" file. Lower level functions should be used for more elaborate encoding/multiplexing tasks.

--- a/docs/src/writing.md
+++ b/docs/src/writing.md
@@ -61,7 +61,7 @@ VideoIO.open_video_out
 ```
 
 ```@docs
-VideoIO.push!
+VideoIO.write
 ```
 
 ```@docs

--- a/docs/src/writing.md
+++ b/docs/src/writing.md
@@ -28,8 +28,8 @@ framestack = map(x->rand(UInt8, 100, 100), 1:100) #vector of 2D arrays
 encoder_options = (crf=23, preset="medium")
 framerate=24
 open_video_out("video.mp4", framestack[1], framerate=framerate, encoder_options=encoder_options) do writer
-    for i in eachindex(framestack)
-        append_encode_mux!(writer, framestack[i], i)
+    for frame in framestack
+        push!(writer, frame)
     end
 end
 ```
@@ -51,7 +51,7 @@ firstimg = load(joinpath(dir, imgnames[1]))
 open_video_out("video.mp4", firstimg, framerate=24, encoder_options=encoder_options) do writer
     @showprogress "Encoding video frames.." for i in eachindex(imgnames)
         img = load(joinpath(dir, imgnames[i]))
-        append_encode_mux!(writer, img, i)
+        push!(writer, img)
     end
 end
 ```
@@ -61,7 +61,7 @@ VideoIO.open_video_out
 ```
 
 ```@docs
-VideoIO.append_encode_mux!
+VideoIO.push!
 ```
 
 ```@docs

--- a/docs/src/writing.md
+++ b/docs/src/writing.md
@@ -29,7 +29,7 @@ encoder_options = (crf=23, preset="medium")
 framerate=24
 open_video_out("video.mp4", framestack[1], framerate=framerate, encoder_options=encoder_options) do writer
     for frame in framestack
-        push!(writer, frame)
+        write(writer, frame)
     end
 end
 ```
@@ -51,7 +51,7 @@ firstimg = load(joinpath(dir, imgnames[1]))
 open_video_out("video.mp4", firstimg, framerate=24, encoder_options=encoder_options) do writer
     @showprogress "Encoding video frames.." for i in eachindex(imgnames)
         img = load(joinpath(dir, imgnames[i]))
-        push!(writer, img)
+        write(writer, img)
     end
 end
 ```

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -9,7 +9,7 @@ using Base: fieldindex, RefValue, sigatomic_begin, sigatomic_end, cconvert
 using Base.GC: @preserve
 import Base: iterate, IteratorSize, IteratorEltype, setproperty!, convert,
     getproperty, unsafe_convert, propertynames, getindex, setindex!, parent,
-    position, unsafe_wrap, unsafe_copyto!, push!
+    position, unsafe_wrap, unsafe_copyto!, write
 
 const VIO_LOCK = ReentrantLock()
 
@@ -176,7 +176,7 @@ VideoIO supports reading and writing video files.
 - `read` and `read!` allow reading frames
 - `seek`, `seekstart`, `skipframe`, and `skipframes` support access of specific frames
 - `VideoIO.save` for encoding an entire framestack in one step
-- `open_video_out`, `push!` for writing frames sequentially to a file
+- `open_video_out`, `write` for writing frames sequentially to a file
 - `gettime` and `counttotalframes` provide information
 
 Here's a brief demo reading through each frame of a video:
@@ -198,7 +198,7 @@ framestack = map(x->rand(UInt8, 100, 100), 1:100) #vector of 2D arrays
 encoder_options = (crf=23, preset="medium")
 open_video_out("video.mp4", framestack[1], framerate=24, encoder_options=encoder_options) do writer
     for frame in framestack
-        push!(writer, frame)
+        write(writer, frame)
     end
 end
 ````

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -9,7 +9,7 @@ using Base: fieldindex, RefValue, sigatomic_begin, sigatomic_end, cconvert
 using Base.GC: @preserve
 import Base: iterate, IteratorSize, IteratorEltype, setproperty!, convert,
     getproperty, unsafe_convert, propertynames, getindex, setindex!, parent,
-    position, unsafe_wrap, unsafe_copyto!
+    position, unsafe_wrap, unsafe_copyto!, push!
 
 const VIO_LOCK = ReentrantLock()
 
@@ -176,7 +176,7 @@ VideoIO supports reading and writing video files.
 - `read` and `read!` allow reading frames
 - `seek`, `seekstart`, `skipframe`, and `skipframes` support access of specific frames
 - `VideoIO.save` for encoding an entire framestack in one step
-- `open_video_out`, `append_encode_mux!` for writing frames sequentially to a file
+- `open_video_out`, `push!` for writing frames sequentially to a file
 - `gettime` and `counttotalframes` provide information
 
 Here's a brief demo reading through each frame of a video:
@@ -197,8 +197,8 @@ using VideoIO
 framestack = map(x->rand(UInt8, 100, 100), 1:100) #vector of 2D arrays
 encoder_options = (crf=23, preset="medium")
 open_video_out("video.mp4", framestack[1], framerate=24, encoder_options=encoder_options) do writer
-    for i in eachindex(framestack)
-        append_encode_mux!(writer, framestack[i], i)
+    for frame in framestack
+        push!(writer, frame)
     end
 end
 ````

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -7,7 +7,7 @@ mutable struct VideoWriter{T<:GraphType}
     packet::AVPacketPtr
     stream_index0::Int
     scanline_major::Bool
-    c::Int
+    num_frames_written::Int
 end
 
 graph_input_frame(r::VideoWriter) = graph_input_frame(r.frame_graph)

--- a/test/writing.jl
+++ b/test/writing.jl
@@ -85,7 +85,7 @@ end
                                     scanline_major = true)
     @test VideoIO.get_codec_name(writer) != "None"
     try
-        VideoIO.append_encode_mux!(writer, img_full_range, 0)
+        VideoIO.push!(writer, img_full_range)
         bwidth = nw * 2
         buff = Vector{UInt8}(undef, bwidth * nh)
         # Input frame should be full range
@@ -101,7 +101,7 @@ end
     finally
         VideoIO.close_video_out!(writer)
     end
-    @test_throws ErrorException VideoIO.append_encode_mux!(writer, img_full_range, 0)
+    @test_throws ErrorException VideoIO.push!(writer, img_full_range)
 end
 
 @testset "Encoding monochrome videos" begin

--- a/test/writing.jl
+++ b/test/writing.jl
@@ -85,7 +85,7 @@ end
                                     scanline_major = true)
     @test VideoIO.get_codec_name(writer) != "None"
     try
-        VideoIO.push!(writer, img_full_range)
+        VideoIO.write(writer, img_full_range)
         bwidth = nw * 2
         buff = Vector{UInt8}(undef, bwidth * nh)
         # Input frame should be full range
@@ -101,7 +101,7 @@ end
     finally
         VideoIO.close_video_out!(writer)
     end
-    @test_throws ErrorException VideoIO.push!(writer, img_full_range)
+    @test_throws ErrorException VideoIO.write(writer, img_full_range)
 end
 
 @testset "Encoding monochrome videos" begin


### PR DESCRIPTION
master
```julia
open_video_out("video.mp4", first(framestack)) do writer
    for i in eachindex(framestack)
        append_encode_mux!(writer, framestack[i], i)
    end
end
```

this PR
```julia
open_video_out("video.mp4", first(framestack)) do writer
    for frame in framestack
        write(writer, frame)
    end
end
```

Given the index had to start at 0, and increment monotonically, we might as well do it internally

Edit: was `push!` now is `write`