### PR TITLE
add VideoIO.load function

### DIFF
--- a/docs/src/reading.md
+++ b/docs/src/reading.md
@@ -6,6 +6,18 @@ Note: Reading of audio streams is not yet implemented
 VideoIO contains a simple high-level interface which allows reading of
 video frames from a supported video file (or from a camera device, shown later).
 
+The simplest form will load the entire video into memory as a vector of image arrays.
+
+```julia
+using VideoIO
+VideoIO.load("video.mp4")
+```
+```@docs
+VideoIO.load
+```
+
+Further examples:
+
 ```julia
 using VideoIO
 

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -171,6 +171,7 @@ end
 """
 VideoIO supports reading and writing video files.
 
+- `VideoIO.load` to load an entire video into memory as a vector of images (a framestack)
 - `openvideo` and `opencamera` provide access to video files and livestreams
 - `read` and `read!` allow reading frames
 - `seek`, `seekstart`, `skipframe`, and `skipframes` support access of specific frames

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -73,6 +73,18 @@ mutable struct VideoReader{transcode, T<:GraphType, I} <: StreamContext
     finished::Bool
 end
 
+
+"""
+    load(filename::String; kwargs...)
+
+Load video file `filename` into memory as vector of image arrays, setting `kwargs` on the `openvideo` process.
+"""
+function load(filename::String; kwargs...)
+    openvideo(filename, kwargs...) do io
+        collect(io)
+    end
+end
+
 show(io::IO, vr::VideoReader) = print(io, "VideoReader(...)")
 
 function iterate(r::VideoReader, state = 0)

--- a/src/testvideos.jl
+++ b/src/testvideos.jl
@@ -18,6 +18,7 @@ mutable struct VideoFile{compression}
     download_url::AbstractString
     numframes::Int
     testframe::Int
+    summarysize::Int
 end
 
 show(io::IO, v::VideoFile) = print(io, """
@@ -29,6 +30,7 @@ show(io::IO, v::VideoFile) = print(io, """
                                      source:       $(v.source)
                                      download_url: $(v.download_url)
                                      numframes:    $(v.numframes)
+                                     summarysize:  $(v.summarysize)
                                    """)
 
 VideoFile(name, description, license, credit, source, download_url, numframes,
@@ -46,6 +48,7 @@ const videofiles  =  Dict(
                                                 "https://archive.org/download/LadybirdOpeningWingsCCBYNatureClip/Ladybird%20opening%20wings%20CC-BY%20NatureClip.mp4",
                                                 397,
                                                 13,
+                                                3216,
                                                 ),
 
                     "annie_oakley.ogg" => VideoFile("annie_oakley.ogg",
@@ -56,6 +59,7 @@ const videofiles  =  Dict(
                                                     "https://upload.wikimedia.org/wikipedia/commons/8/87/Annie_Oakley_shooting_glass_balls%2C_1894.ogv",
                                                     726,
                                                     2,
+                                                    5848,
                                                     ),
 
                     "crescent-moon.ogv" => VideoFile("crescent-moon.ogv",
@@ -66,6 +70,7 @@ const videofiles  =  Dict(
                                                      "https://upload.wikimedia.org/wikipedia/commons/e/ef/2010-10-10-Lune.ogv",
                                                      1213,
                                                      1,
+                                                     9744,
                                                      ),
 
                     "black_hole.webm" => VideoFile("black_hole.webm",
@@ -76,6 +81,7 @@ const videofiles  =  Dict(
                                                    "https://upload.wikimedia.org/wikipedia/commons/1/13/Artist%E2%80%99s_impression_of_the_black_hole_inside_NGC_300_X-1_%28ESO_1004c%29.webm",
                                                    597,
                                                    1,
+                                                   4816,
                                                    ),
                      )
 

--- a/src/testvideos.jl
+++ b/src/testvideos.jl
@@ -34,9 +34,9 @@ show(io::IO, v::VideoFile) = print(io, """
                                    """)
 
 VideoFile(name, description, license, credit, source, download_url, numframes,
-          testframe) = VideoFile{:raw}(name, description, license, credit,
+          testframe, summarysize) = VideoFile{:raw}(name, description, license, credit,
                                        source, download_url, numframes,
-                                       testframe)
+                                       testframe, summarysize)
 
 # Standard test videos
 const videofiles  =  Dict(

--- a/test/reading.jl
+++ b/test/reading.jl
@@ -120,12 +120,13 @@
                 close(f)
             end
 
-            @show testvid_path
-            framestack = VideoIO.load(testvid_path)
-            @test length(framestack) == VideoIO.TestVideos.videofiles[name].numframes
-            @test Base.summarysize(framestack) == VideoIO.TestVideos.videofiles[name].summarysize
-            framestack = nothing
-            GC.gc()
+            if occursin("annie_oakley", name)
+                framestack = VideoIO.load(testvid_path)
+                @test length(framestack) == VideoIO.TestVideos.videofiles[name].numframes
+                @test Base.summarysize(framestack) == VideoIO.TestVideos.videofiles[name].summarysize
+                framestack = nothing
+                GC.gc()
+            end
         end
     end
 end

--- a/test/reading.jl
+++ b/test/reading.jl
@@ -120,8 +120,10 @@
                 close(f)
             end
 
+            @show testvid_path
             framestack = VideoIO.load(testvid_path)
             @test length(framestack) == VideoIO.TestVideos.videofiles[name].numframes
+            @test Base.summarysize(framestack) == VideoIO.TestVideos.videofiles[name].summarysize
             framestack = nothing
             GC.gc()
         end

--- a/test/reading.jl
+++ b/test/reading.jl
@@ -119,6 +119,9 @@
             finally
                 close(f)
             end
+
+            v = VideoIO.load(f)
+            @test length(v) == VideoIO.TestVideos.videofiles[name].numframes
         end
     end
 end

--- a/test/reading.jl
+++ b/test/reading.jl
@@ -120,8 +120,10 @@
                 close(f)
             end
 
-            v = VideoIO.load(testvid_path)
-            @test length(v) == VideoIO.TestVideos.videofiles[name].numframes
+            framestack = VideoIO.load(testvid_path)
+            @test length(framestack) == VideoIO.TestVideos.videofiles[name].numframes
+            framestack = nothing
+            GC.gc()
         end
     end
 end

--- a/test/reading.jl
+++ b/test/reading.jl
@@ -120,7 +120,7 @@
                 close(f)
             end
 
-            v = VideoIO.load(f)
+            v = VideoIO.load(testvid_path)
             @test length(v) == VideoIO.TestVideos.videofiles[name].numframes
         end
     end


### PR DESCRIPTION
Adds a basic `load` function to load the entire video into memory as a framestack

```julia
VideoIO.load("video.mp4")
```

Along with the also non-exported `VideoIO.save`, these can be the functions we link to FileIO