### PR TITLE
Enable adjustable codec multithreading (significant read and write speed up!)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-runtest@master
+        env:
+          JULIA_NUM_THREADS: 2
       - uses: julia-actions/julia-processcoverage@master
       - uses: codecov/codecov-action@master
         with:

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -248,7 +248,8 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
                      target_colorspace_details = nothing,
                      allow_vio_gray_transform = true,
                      swscale_options::OptionsT = (;),
-                     sws_color_options::OptionsT = (;)) where I
+                     sws_color_options::OptionsT = (;),
+                     thread_count::Int = Threads.nthreads()) where I
     bad_px_type = transcode && target_format !== nothing &&
         !is_pixel_type_supported(target_format)
     bad_px_type && error("Unsupported pixel format $target_format")
@@ -268,6 +269,7 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
 
     # Create decoder context
     codec_context = AVCodecContextPtr(codec) # Allocates
+    codec_context.thread_count = thread_count
     # Transfer parameters to decoder context
     ret = avcodec_parameters_to_context(codec_context, stream.codecpar)
     ret < 0 && error("Could not copy the codec parameters to the decoder")
@@ -584,6 +586,8 @@ arguments listed below.
 - `sws_color_options::OptionsT = (;)`: Additional keyword arguments passed to
     [sws_setColorspaceDetails]
     (http://ffmpeg.org/doxygen/2.5/group__libsws.html#ga541bdffa8149f5f9203664f955faa040).
+- `thread_count::Int = Threads.nthreads()`: The number of threads the codec is
+    allowed to use. Defaults to the same as Julia.
 """
 openvideo(s::Union{IO, AbstractString, AVInput}, args...; kwargs...) =
     VideoReader(s, args...; kwargs...)


### PR DESCRIPTION
I had assumed that ffmpeg/h.264 automatically handled multithreading, but it seems not to be the case.
The small change in this PR is based on https://stackoverflow.com/questions/43251612/ffmpeg-how-to-use-multithreading

I propose that the default is set to `Threads.nthreads()` but that users can tune it as they wish.

## Master
```julia
julia> function foo()
    f = openvideo("vid.mp4")
    i = 1
    img = read(f)
    i += 1 
    while !eof(f)
        read!(f, img)
        i += 1
    end
    close(f)
    @show i
end


julia> @time foo();
i = 1789
 27.231079 seconds (1.91 k allocations: 9.032 MiB, 0.03% gc time)
```
## This PR
Where `Threads.nthreads() == 16`
```julia
julia> @time foo();
i = 1789
  3.339067 seconds (1.91 k allocations: 9.032 MiB)
```


Saves about 1 minute (6 -> 5 mins on ubuntu) in CI with only 2 threads 