### PR TITLE
Enable adjustable codec multithreading

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,8 +26,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-runtest@master
-        env:
-          JULIA_NUM_THREADS: 2
       - uses: julia-actions/julia-processcoverage@master
       - uses: codecov/codecov-action@master
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-runtest@master
+        env:
+          JULIA_NUM_THREADS: 2
       - uses: julia-actions/julia-processcoverage@master
       - uses: codecov/codecov-action@master
         with:

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -248,7 +248,8 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
                      target_colorspace_details = nothing,
                      allow_vio_gray_transform = true,
                      swscale_options::OptionsT = (;),
-                     sws_color_options::OptionsT = (;)) where I
+                     sws_color_options::OptionsT = (;),
+                     thread_count::Int = Threads.nthreads()) where I
     bad_px_type = transcode && target_format !== nothing &&
         !is_pixel_type_supported(target_format)
     bad_px_type && error("Unsupported pixel format $target_format")
@@ -268,6 +269,7 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
 
     # Create decoder context
     codec_context = AVCodecContextPtr(codec) # Allocates
+    codec_context.thread_count = thread_count
     # Transfer parameters to decoder context
     ret = avcodec_parameters_to_context(codec_context, stream.codecpar)
     ret < 0 && error("Could not copy the codec parameters to the decoder")
@@ -584,6 +586,8 @@ arguments listed below.
 - `sws_color_options::OptionsT = (;)`: Additional keyword arguments passed to
     [sws_setColorspaceDetails]
     (http://ffmpeg.org/doxygen/2.5/group__libsws.html#ga541bdffa8149f5f9203664f955faa040).
+- `thread_count::Int = Threads.nthreads()`: The number of threads the codec is
+    allowed to use. Defaults to the same as Julia.
 """
 openvideo(s::Union{IO, AbstractString, AVInput}, args...; kwargs...) =
     VideoReader(s, args...; kwargs...)

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -249,7 +249,7 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
                      allow_vio_gray_transform = true,
                      swscale_options::OptionsT = (;),
                      sws_color_options::OptionsT = (;),
-                     thread_count::Int = Threads.nthreads()) where I
+                     thread_count::Union{Nothing, Int} = Sys.CPU_THREADS) where I
     bad_px_type = transcode && target_format !== nothing &&
         !is_pixel_type_supported(target_format)
     bad_px_type && error("Unsupported pixel format $target_format")
@@ -269,7 +269,7 @@ function VideoReader(avin::AVInput{I}, video_stream = 1;
 
     # Create decoder context
     codec_context = AVCodecContextPtr(codec) # Allocates
-    codec_context.thread_count = thread_count
+    codec_context.thread_count = thread_count === nothing ? codec_context.thread_count : thread_count
     # Transfer parameters to decoder context
     ret = avcodec_parameters_to_context(codec_context, stream.codecpar)
     ret < 0 && error("Could not copy the codec parameters to the decoder")
@@ -586,8 +586,8 @@ arguments listed below.
 - `sws_color_options::OptionsT = (;)`: Additional keyword arguments passed to
     [sws_setColorspaceDetails]
     (http://ffmpeg.org/doxygen/2.5/group__libsws.html#ga541bdffa8149f5f9203664f955faa040).
-- `thread_count::Int = Threads.nthreads()`: The number of threads the codec is
-    allowed to use. Defaults to the same as Julia.
+- `thread_count::Union{Nothing, Int} = Sys.CPU_THREADS`: The number of threads the codec is
+    allowed to use or `nothing` for default codec behavior. Defaults to `Sys.CPU_THREADS`.
 """
 openvideo(s::Union{IO, AbstractString, AVInput}, args...; kwargs...) =
     VideoReader(s, args...; kwargs...)

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -240,7 +240,8 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                      pix_fmt_loss_flags = 0,
                      input_colorspace_details = nothing,
                      allow_vio_gray_transform = true,
-                     sws_color_options::OptionsT = (;)) where T
+                     sws_color_options::OptionsT = (;),
+                     thread_count::Int = Threads.nthreads()) where T
     framerate > 0 || error("Framerate must be strictly positive")
 
     if haskey(encoder_options, :priv_data)
@@ -300,6 +301,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
     codec_context.time_base = target_timebase
     codec_context.framerate = framerate_rat
     codec_context.pix_fmt = encoding_pix_fmt
+    codec_context.thread_count = thread_count
 
     if format_context.oformat.flags & AVFMT_GLOBALHEADER != 0
         codec_context.flags |= AV_CODEC_FLAG_GLOBAL_HEADER
@@ -453,6 +455,8 @@ occurred.
 - `sws_color_options::OptionsT = (;)`: Additional keyword arguments passed to
     [sws_setColorspaceDetails]
     (http://ffmpeg.org/doxygen/2.5/group__libsws.html#ga541bdffa8149f5f9203664f955faa040).
+- `thread_count::Int = Threads.nthreads()`: The number of threads the codec is
+    allowed to use. Defaults to the same as Julia.
 
 See also: [`write`](@ref), [`close_video_out!`](@ref)
 """

--- a/src/encoding.jl
+++ b/src/encoding.jl
@@ -241,7 +241,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
                      input_colorspace_details = nothing,
                      allow_vio_gray_transform = true,
                      sws_color_options::OptionsT = (;),
-                     thread_count::Int = Threads.nthreads()) where T
+                     thread_count::Union{Nothing, Int} = nothing) where T
     framerate > 0 || error("Framerate must be strictly positive")
 
     if haskey(encoder_options, :priv_data)
@@ -301,7 +301,7 @@ function VideoWriter(filename::AbstractString, ::Type{T},
     codec_context.time_base = target_timebase
     codec_context.framerate = framerate_rat
     codec_context.pix_fmt = encoding_pix_fmt
-    codec_context.thread_count = thread_count
+    codec_context.thread_count = thread_count === nothing ? codec_context.thread_count : thread_count
 
     if format_context.oformat.flags & AVFMT_GLOBALHEADER != 0
         codec_context.flags |= AV_CODEC_FLAG_GLOBAL_HEADER
@@ -455,8 +455,8 @@ occurred.
 - `sws_color_options::OptionsT = (;)`: Additional keyword arguments passed to
     [sws_setColorspaceDetails]
     (http://ffmpeg.org/doxygen/2.5/group__libsws.html#ga541bdffa8149f5f9203664f955faa040).
-- `thread_count::Int = Threads.nthreads()`: The number of threads the codec is
-    allowed to use. Defaults to the same as Julia.
+- `thread_count::Union{Nothing, Int} = nothing`: The number of threads the codec is
+    allowed to use, or `nothing` for default codec behavior. Defaults to `nothing`.
 
 See also: [`write`](@ref), [`close_video_out!`](@ref)
 """


### PR DESCRIPTION
I had assumed that ffmpeg/h.264 automatically handled multithreading, but it seems not to be the case.
The small change in this PR is based on https://stackoverflow.com/questions/43251612/ffmpeg-how-to-use-multithreading

I propose that the default is set to `Threads.nthreads()` but that users can tune it as they wish.

# Decoding

## Master
```julia
julia> function foo()
    f = openvideo("vid.mp4")
    i = 1
    img = read(f)
    i += 1 
    while !eof(f)
        read!(f, img)
        i += 1
    end
    close(f)
    @show i
end


julia> @time foo();
i = 1789
 27.231079 seconds (1.91 k allocations: 9.032 MiB, 0.03% gc time)
```
## This PR
Where `Threads.nthreads() == 16`
```julia
julia> @time foo();
i = 1789
  3.339067 seconds (1.91 k allocations: 9.032 MiB)
```

# Encoding

Not much of an improvement in my case, but might be tunable for a given system

## Master
```julia
julia> imgstack = map(_->rand(UInt8, 100,100), 1:1000);

julia> @time VideoIO.save("vid.mp4", imgstack); # what master has. Assumed to do something auto
  2.168394 seconds (30.54 M allocations: 638.736 MiB, 3.87% gc time, 6.37% compilation time)
```

## This PR
```julia
julia> @time VideoIO.save("vid.mp4", imgstack); # defaults to thread_count = Threads.nthreads() == 6
  2.025728 seconds (30.01 M allocations: 610.917 MiB, 4.35% gc time)
```

Saves about 1 minute (6 -> 5 mins on ubuntu) in CI with only 2 threads 