### PR TITLE
fix error of `opencamera()`

### DIFF
--- a/src/avdictionary.jl
+++ b/src/avdictionary.jl
@@ -28,7 +28,6 @@ end
 
 Base.empty!(d::AVDict) = libffmpeg.av_dict_free(d.ref_ptr_dict)
 
-Base.convert(::Type{Ref{Ptr{AVDictionary}}}, d::AVDict) = d.ref_ptr_dict
 Base.cconvert(::Type{Ptr{Ptr{AVDictionary}}}, d::AVDict) = d.ref_ptr_dict
 
 function setindex!(d::AVDict, value, key)

--- a/src/avdictionary.jl
+++ b/src/avdictionary.jl
@@ -1,5 +1,5 @@
 import .libffmpeg: AVDictionary
-import Base: getindex, setindex!, iterate, length, empty!
+import Base: getindex, setindex!, iterate, length, empty!, cconvert
 
 mutable struct AVDict <: AbstractDict{String, String}
     ref_ptr_dict::Ref{Ptr{AVDictionary}}
@@ -29,6 +29,7 @@ end
 Base.empty!(d::AVDict) = libffmpeg.av_dict_free(d.ref_ptr_dict)
 
 Base.convert(::Type{Ref{Ptr{AVDictionary}}}, d::AVDict) = d.ref_ptr_dict
+Base.cconvert(::Type{Ptr{Ptr{AVDictionary}}}, d::AVDict) = d.ref_ptr_dict
 
 function setindex!(d::AVDict, value, key)
     libffmpeg.av_dict_set(d.ref_ptr_dict, string(key), string(value), 0)

--- a/src/avdictionary.jl
+++ b/src/avdictionary.jl
@@ -1,5 +1,5 @@
 import .libffmpeg: AVDictionary
-import Base: getindex, setindex!, iterate, length, empty!, cconvert
+import Base: getindex, setindex!, iterate, length, empty!
 
 mutable struct AVDict <: AbstractDict{String, String}
     ref_ptr_dict::Ref{Ptr{AVDictionary}}


### PR DESCRIPTION
This PR addresses #341.
I compared both solutions proposed in the chat and found that `cconvert()` is preferred over `unsafe_convert()` as I assumed, so I implemented the solution for `cconvert()`.

I was not completely sure whether `convert()` is needed somewhere in the code - although I couldn't find any evidence in the code - so I kept it.

EDIT: added "not" in the phrase above...