### PR TITLE
Lazy-load cameras to improve package load time

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.4'
+          version: 1
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -30,7 +30,7 @@ include("encoding.jl")
 include("testvideos.jl")
 using .TestVideos
 
-@static if Sys.islinux()
+if Sys.islinux()
     import Glob
     function init_camera_devices()
         append!(CAMERA_DEVICES, Glob.glob("video*", "/dev"))

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -30,7 +30,7 @@ include("encoding.jl")
 include("testvideos.jl")
 using .TestVideos
 
-if Sys.islinux()
+@static if Sys.islinux()
     import Glob
     function init_camera_devices()
         append!(CAMERA_DEVICES, Glob.glob("video*", "/dev"))
@@ -40,9 +40,7 @@ if Sys.islinux()
         DEFAULT_CAMERA_OPTIONS["framerate"] = 30
         DEFAULT_CAMERA_DEVICE[] = isempty(CAMERA_DEVICES) ? "" : CAMERA_DEVICES[1]
     end
-end
-
-if Sys.iswindows()
+elseif Sys.iswindows()
     function init_camera_devices()
         append!(CAMERA_DEVICES, get_camera_devices(ffmpeg, "dshow", "dummy"))
         DEFAULT_CAMERA_FORMAT[] = libffmpeg.av_find_input_format("dshow")
@@ -54,9 +52,7 @@ if Sys.iswindows()
             isempty(CAMERA_DEVICES) ? "0" : CAMERA_DEVICES[1]
         )
     end
-end
-
-if Sys.isapple()
+elseif Sys.isapple()
     function init_camera_devices()
         try
             append!(CAMERA_DEVICES, get_camera_devices(ffmpeg, "avfoundation", "\"\""))
@@ -119,8 +115,6 @@ function __init__()
     av_register_all()
 
     libffmpeg.avdevice_register_all()
-    init_camera_devices()
-    init_camera_settings()
 
     @require GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a" begin
         # Define read and retrieve for Images

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -1015,12 +1015,23 @@ function get_camera_devices(ffmpeg, idev, idev_name)
 end
 
 function opencamera(
-        device=DEFAULT_CAMERA_DEVICE[],
-        format=DEFAULT_CAMERA_FORMAT[],
-        options = DEFAULT_CAMERA_OPTIONS,
+        device=nothing,
+        format=nothing,
+        options=nothing,
         args...;
         kwargs...
     )
+
+    if isnothing(device) || isnothing(format) || isnothing(options) || isempty(CAMERA_DEVICES)
+        # do this only if needed
+        init_camera_devices()
+        init_camera_settings()
+    end
+
+    device = something(device, DEFAULT_CAMERA_DEVICE[])
+    format = something(format, DEFAULT_CAMERA_FORMAT[])
+    options = something(options, DEFAULT_CAMERA_OPTIONS)
+
     camera = AVInput(device, format, options)
     VideoReader(camera, args...; kwargs...)
 end

--- a/src/avio.jl
+++ b/src/avio.jl
@@ -1028,9 +1028,9 @@ function opencamera(
         init_camera_settings()
     end
 
-    device = something(device, DEFAULT_CAMERA_DEVICE[])
-    format = something(format, DEFAULT_CAMERA_FORMAT[])
-    options = something(options, DEFAULT_CAMERA_OPTIONS)
+    device = @something(device, DEFAULT_CAMERA_DEVICE[])
+    format = @something(format, DEFAULT_CAMERA_FORMAT[])
+    options = @something(options, DEFAULT_CAMERA_OPTIONS)
 
     camera = AVInput(device, format, options)
     VideoReader(camera, args...; kwargs...)


### PR DESCRIPTION
Defers populating available cameras and identifying the default until the user requests cameras, which helps package load time.

Before
```
julia> @time using VideoIO
  2.679612 seconds (3.20 M allocations: 237.017 MiB, 3.63% gc time, 34.81% compilation time)
```

This PR
```
julia> @time using VideoIO
  2.183519 seconds (2.97 M allocations: 221.639 MiB, 3.81% gc time, 27.94% compilation time)
```