### PR TITLE
add a precompile workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 
 [compat]
 ColorTypes = "0.9, 0.10, 0.11"
@@ -23,4 +24,5 @@ Glob = "1.2"
 ImageCore = "0.8, 0.9"
 ProgressMeter = "1.2"
 Requires = "1.0"
+SnoopPrecompile = "1"
 julia = "1.6"

--- a/src/VideoIO.jl
+++ b/src/VideoIO.jl
@@ -5,6 +5,7 @@ using Requires, Dates, ProgressMeter
 using ImageCore: channelview, rawview
 using ColorTypes: RGB, Gray, N0f8, N6f10, YCbCr, Normed, red, green, blue
 using FileIO: File
+using SnoopPrecompile
 
 using Base: fieldindex, RefValue, cconvert
 using Base.GC: @preserve
@@ -190,6 +191,27 @@ function __init__()
                 close(camera)
             end
         end
+    end
+end
+
+@precompile_setup begin
+    imgstack = map(_->rand(UInt8, 10, 10), 1:10)
+    @precompile_all_calls begin
+        fname = string(tempname(), ".mp4")
+        VideoIO.save(fname, imgstack)
+        VideoIO.save(fname, VideoIO.load(fname)) # the loaded video is RGB type
+        r = openvideo(fname)
+        img = read(r)
+        while !eof(r)
+            read!(r, img)
+        end
+        seekstart(r)
+        seek(r, 0.01)
+        skipframe(r)
+        skipframes(r, 3)
+        gettime(r)
+        counttotalframes(r)
+        close(r)
     end
 end
 


### PR DESCRIPTION
Seems good to do, although the benefit is minor

master
```
julia> @time using VideoIO
  2.099601 seconds (4.06 M allocations: 289.931 MiB, 4.39% gc time, 5.40% compilation time: 1% of which was recompilation)

julia> imgstack = map(_->rand(UInt8, 10, 10), 1:10);

julia> @time begin
           fname = string(tempname(), ".mp4")
           VideoIO.save(fname, imgstack)
           VideoIO.save(fname, VideoIO.load(fname)) # the loaded video is RGB type
           r = openvideo(fname)
           img = read(r)
           while !eof(r)
               read!(r, img)
           end
           seek(r, 0.1)
           seekstart(r)
           skipframe(r)
           skipframes(r, 3)
           gettime(r)
           counttotalframes(r)
       end
  1.683524 seconds (4.56 M allocations: 234.308 MiB, 4.05% gc time, 98.63% compilation time)
10
```

PR on 1.8
```
julia> @time using VideoIO
  2.312653 seconds (4.35 M allocations: 311.221 MiB, 5.59% gc time, 3.93% compilation time: 2% of which was recompilation)

julia> imgstack = map(_->rand(UInt8, 10, 10), 1:10);

julia> @time begin
           fname = string(tempname(), ".mp4")
           VideoIO.save(fname, imgstack)
           VideoIO.save(fname, VideoIO.load(fname)) # the loaded video is RGB type
           r = openvideo(fname)
           img = read(r)
           while !eof(r)
               read!(r, img)
           end
           seek(r, 0.1)
           seekstart(r)
           skipframe(r)
           skipframes(r, 3)
           gettime(r)
           counttotalframes(r)
       end
  1.010267 seconds (147.65 k allocations: 4.662 MiB, 97.82% compilation time)
10
```

PR on 1.9
```
julia> @time using VideoIO
  2.646890 seconds (4.46 M allocations: 316.189 MiB, 5.66% gc time, 14.16% compilation time: 8% of which was recompilation)

julia> imgstack = map(_->rand(UInt8, 10, 10), 1:10);

julia> @time begin
           fname = string(tempname(), ".mp4")
           VideoIO.save(fname, imgstack)
           VideoIO.save(fname, VideoIO.load(fname)) # the loaded video is RGB type
           r = openvideo(fname)
           img = read(r)
           while !eof(r)
               read!(r, img)
           end
           seek(r, 0.1)
           seekstart(r)
           skipframe(r)
           skipframes(r, 3)
           gettime(r)
           counttotalframes(r)
       end
  1.010661 seconds (147.65 k allocations: 4.662 MiB, 98.08% compilation time)
10
```