### PR TITLE
Avoid exporting garbage from `libffmpeg`

### DIFF
--- a/lib/libffmpeg.jl
+++ b/lib/libffmpeg.jl
@@ -21844,8 +21844,10 @@ const FF_API_SWS_VECTOR = LIBSWSCALE_VERSION_MAJOR < 6
 
 struct_types = Type[]
 # Export everything
-for name in names(@__MODULE__, all=true)
-    name in [Symbol("#eval"), Symbol("#include"), :include, :eval] && continue
+for name in names(@__MODULE__; all=true)
+    if name in (:include, :eval) || startswith(string(name), "#")
+        continue
+    end
     @eval begin
         export $name
         $name isa Type && isstructtype($name) && push!(struct_types, $name)


### PR DESCRIPTION
The autoexport mechanism in `libffmpeg` is exporting literally _everything_, including over one thousand of totally useless names, like `Symbol("##meta#58")` which happens to be already defined in `VideoIO`, causing a clash.