### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,5 +56,6 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
 


### PR DESCRIPTION
Fix Codecov action. 
Ref: https://discourse.julialang.org/t/psa-new-version-of-codecov-action-requires-additional-setup/109857/1

I have added CODECOV_TOKEN as an organization secret so this should be the only change required