### PR TITLE
Account for async stream reads (cameras)

### DIFF
--- a/src/avio.jl
+++ b/src/avio.jl
@@ -121,8 +121,18 @@ function pump(avin::AVInput)
         end
 
         if ret < 0
-            avin.finished = true
-            break
+            if ret == VIO_AVERROR_EOF
+                avin.finished = true
+                break
+            elseif ret == -Libc.EAGAIN
+                # Nothing ready yet - for live streams, this is normal
+                # Return -1 to indicate no frame available right now
+                return -1
+            else
+                # Real error - treat as EOF
+                avin.finished = true
+                break
+            end
         end
         stream_index = avin.packet.stream_index
         if stream_index in avin.listening
@@ -155,10 +165,20 @@ pump(r::StreamContext) = pump(r.avin)
 function pump_until_frame(r, err = false)
     while !frame_is_queued(r)
         idx = pump(r.avin)
-        idx == r.stream_index0 && break
-        if idx == -1
-            err ? throw(EOFError()) : return false
+        if idx == r.stream_index0
+            break
+        elseif idx == -1
+            # av_read_frame returned EAGAIN (nothing ready yet) or EOF
+            if r.avin.finished
+                # Real EOF - no more frames coming
+                err ? throw(EOFError()) : return false
+            else
+                # EAGAIN - nothing ready yet, wait a bit and retry
+                sleep(0.01)  # 10ms as recommended by FFmpeg docs
+                continue
+            end
         end
+        # idx is some other stream index, continue pumping
     end
     return true
 end
@@ -405,7 +425,7 @@ Like containers, elementary streams also can store timestamps, 1/time_base is th
 
 For some codecs, the time base is closer to the field rate than the frame rate.
 Most notably, H.264 and MPEG-2 specify time_base as half of frame duration if no telecine is used ...
-Set to time_base ticks per frame. Default 1, e.g., H.264/MPEG-2 set it to 2. 
+Set to time_base ticks per frame. Default 1, e.g., H.264/MPEG-2 set it to 2.
 =#
 framerate(f::VideoReader) =
     f.codec_context.time_base.den // f.codec_context.time_base.num // f.codec_context.ticks_per_frame


### PR DESCRIPTION
Fixes https://github.com/JuliaIO/VideoIO.jl/issues/343

Based on this insight from ChatGPT

---

<html><head></head><body><h3>Why you see a difference</h3>
<h4>macOS&nbsp;(<code inline="">avfoundation</code>)</h4>
<ul>
<li>
<p>The AVFoundation demuxer uses <strong>asynchronous capture callbacks</strong>.</p>
</li>
<li>
<p><code inline="">avf_read_packet()</code> simply pops the next frame from an internal queue; if the queue is empty it returns <code inline="">AVERROR(EAGAIN)</code> immediately instead of blocking.</p>
</li>
<li>
<p>Because of this design, <code inline="">av_read_frame()</code> behaves <strong>non‑blocking on macOS</strong>.</p>
</li>
</ul>
<h4>Linux&nbsp;(<code inline="">v4l2</code>) / Windows&nbsp;(<code inline="">dshow</code>)</h4>
<ul>
<li>
<p>These back‑ends talk to the driver with blocking <code inline="">ioctl</code> / <code inline="">ReadFile</code> calls.</p>
</li>
<li>
<p>The call sleeps inside the kernel until a fresh buffer is ready, so by the time <code inline="">av_read_frame()</code> returns you already have a packet.</p>
</li>
<li>
<p>They still <em>can</em> return <code inline="">EAGAIN</code>, but only if the device was opened <code inline="">O_NONBLOCK</code> (not the default).</p>
</li>
</ul>
<h3>Is the macOS behaviour “wrong”?</h3>
<p>No—just different:</p>
<ul>
<li>
<p>The demuxer advertises <code inline="">AVFMT_FLAG_NONBLOCK</code>, so callers <strong>must handle</strong> <code inline="">EAGAIN</code>.</p>
</li>
<li>
<p>FFmpeg’s own CLI handles it by retrying with a short sleep.</p>
</li>
</ul>
<hr>
<h3>Practical ways to deal with it (without busy‑waiting)</h3>

Approach | What you do | Pros | Cons
-- | -- | -- | --
Poll with back‑off | while ((ret = av_read_frame(ctx,&pkt)) == AVERROR(EAGAIN)) av_usleep(5000); | Simple, portable | Still a retry loop, but minimal CPU load
Dedicated capture thread | Run the loop above in its own thread; push real packets to a queue | Main thread just waits on a condition variable | Slightly more code
Use FFmpeg’s poll‑fd helper | In FFmpeg ≥ 6 call avformat_get_poll_fd() and wait with poll()/select() | Fully event‑driven; integrates with GUI run‑loops | Requires newer FFmpeg
Patch FFmpeg | Replace the early EAGAIN return with a blocking pthread_cond_wait() | Gives exactly the semantics you want | Maintain a local fork


<hr>
<h3>Recommended pattern</h3>
<pre><code class="language-c">for (;;) {
    int ret = av_read_frame(fmt_ctx, &amp;pkt);
    if (!ret) {              /* got a frame */
        process_packet(&amp;pkt);
        break;
    }
    if (ret == AVERROR(EAGAIN)) {   /* nothing ready yet */
        av_usleep(10 * 1000);       /* 10 ms back‑off */
        continue;
    }
    if (ret == AVERROR_EOF)         /* device closed */
        break;

    av_log(NULL, AV_LOG_ERROR, "capture error: %s\n", av_err2str(ret));
    break;
}
</code></pre>
<p>With a 5–10 ms back‑off the loop sleeps almost all the time and uses negligible CPU, yet still delivers each frame as soon as it arrives.</p>
<hr>
<p><strong>Bottom line:</strong><br>
The non‑blocking behavior on macOS is expected. Handle <code inline="">EAGAIN</code> by sleeping briefly, using a background thread, or by waiting on the poll‑fd helper in newer FFmpeg versions.</p></body></html>